### PR TITLE
Fixacl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 extra
+pyvenv.cfg
 .coverage
 .python-version
 *.egg-info

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- [chg] only editor/manager can view booking data
+  [mamico]
 
 
 1.3.3 (2021-08-09)

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,8 +1,0 @@
-home = /usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7
-implementation = CPython
-version_info = 3.7.4.final.0
-virtualenv = 20.0.27
-include-system-site-packages = false
-base-prefix = /usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7
-base-exec-prefix = /usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7
-base-executable = /usr/local/opt/python/bin/python3.7

--- a/src/redturtle/prenotazioni/browser/prenotazione_add.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_add.py
@@ -257,7 +257,7 @@ class AddForm(form.AddForm):
             ):
                 f.mode = "hidden"
 
-        if not api.user.is_anonymous():
+        if not api.user.is_anonymous() and not api.user.has_permission("Modify portal content", obj=self.context):
             user = api.user.get_current()
             for f in self.widgets:
                 value = user.getProperty(f, "")

--- a/src/redturtle/prenotazioni/browser/prenotazione_add.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_add.py
@@ -259,11 +259,11 @@ class AddForm(form.AddForm):
 
         if not api.user.is_anonymous():
             user = api.user.get_current()
-            for field in self.widgets:
-                value = user.getProperty(field, "")
+            for f in self.widgets:
+                value = user.getProperty(f, "")
                 if value:
-                    self.widgets[field].value = value
-                    self.widgets[field].readonly = "readonly"
+                    self.widgets[f].value = value
+                    self.widgets[f].readonly = "readonly"
 
     @property
     @memoize

--- a/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
@@ -86,13 +86,6 @@ class PrenotazioniContextState(BrowserView):
 
     @property
     @memoize
-    def user_permissions(self):
-        """ The dict with the user permissions
-        """
-        return api.user.get_permissions(obj=self.context)
-
-    @property
-    @memoize
     def user_roles(self):
         """ The dict with the user permissions
         """
@@ -105,9 +98,7 @@ class PrenotazioniContextState(BrowserView):
         """
         if self.is_anonymous:
             return False
-        if self.user_permissions.get("Modify portal content", False):
-            return True
-        return False
+        return api.user.has_permission("Modify portal content", obj=self.context)
 
     @property
     @memoize
@@ -118,8 +109,8 @@ class PrenotazioniContextState(BrowserView):
             return False
         if self.user_can_manage:
             return True
-        if u"Reader" in self.user_roles:
-            return True
+        # if u"Reader" in self.user_roles:
+        #     return True
         return False
 
     @property

--- a/src/redturtle/prenotazioni/browser/week.py
+++ b/src/redturtle/prenotazioni/browser/week.py
@@ -55,8 +55,7 @@ class View(BaseView):
         """
         if api.user.is_anonymous():
             return False
-        permissions = api.user.get_permissions(obj=self.context)
-        return permissions.get("Modify portal content", False)
+        return api.user.has_permission("Modify portal content", obj=self.context)
 
     @property
     @memoize
@@ -68,7 +67,8 @@ class View(BaseView):
             return False
         if self.prenotazioni.user_can_manage:
             return True
-        return u"Reader" in api.user.get_roles(obj=self.context)
+        # return u"Reader" in api.user.get_roles(obj=self.context)
+        return False
 
     @property
     @memoize


### PR DESCRIPTION
* rimosso uso di api.user.get_permissions che ha prestazioni pessime al suo posto usata has_permission
* solo gli utenti che hanno ruolo di gestione possono vedere le prenotazioni degli altri
* se sono gestore non mi deve essere precompilata la form con i dati di prenotazione