### PR TITLE
chore: updated time label of booking add view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- chore: updated time label of booking add view
+  [sara]
 
 
 1.5.2 (2022-11-30)

--- a/src/redturtle/prenotazioni/browser/prenotazione_add.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_add.py
@@ -146,7 +146,7 @@ class AddForm(form.AddForm):
         localized_date = self.localized_time(booking_date)
         return _(
             "label_selected_date",
-            u"Selected date: ${date} — Time slot: ${slot}",
+            u"Selected date: ${date} — Time: ${slot}",
             mapping={"date": localized_date, "slot": booking_date.hour()},
         )
 

--- a/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
@@ -882,7 +882,7 @@ msgstr "label_required_booking_fields"
 msgid "label_same_day_booking_disallowed"
 msgstr "label_same_day_booking_disallowed"
 
-#. Default: "Selected date: ${date} — Time slot: ${slot}"
+#. Default: "Selected date: ${date} — Time: ${slot}"
 #: redturtle/prenotazioni/browser/prenotazione_add.py:153
 msgid "label_selected_date"
 msgstr "label_selected_date"

--- a/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
@@ -881,10 +881,10 @@ msgstr "Campi obbligatori"
 msgid "label_same_day_booking_disallowed"
 msgstr "Disabilita la prenotazione per lo stesso giorno"
 
-#. Default: "Selected date: ${date} — Time slot: ${slot}"
+#. Default: "Selected date: ${date} — Time: ${slot}"
 #: redturtle/prenotazioni/browser/prenotazione_add.py:153
 msgid "label_selected_date"
-msgstr "Data selezionata: ${date} — Fascia oraria: ${slot}"
+msgstr "Data selezionata: ${date} — Alle ore: ${slot}"
 
 #. Default: "Start date "
 #: redturtle/prenotazioni/browser/prenotazioni_search.py:53

--- a/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
+++ b/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
@@ -878,7 +878,7 @@ msgstr ""
 msgid "label_same_day_booking_disallowed"
 msgstr ""
 
-#. Default: "Selected date: ${date} — Time slot: ${slot}"
+#. Default: "Selected date: ${date} — Time: ${slot}"
 #: redturtle/prenotazioni/browser/prenotazione_add.py:153
 msgid "label_selected_date"
 msgstr ""


### PR DESCRIPTION
Il messaggio di aggiunta della prenotazione risultava fuorviante, per cui si è deciso di mostrare:
_Data selezionata: 05/12/2022 alle ore 10:00_

invece di

![image (2)](https://user-images.githubusercontent.com/43245702/205695939-fbd03da8-762c-4c4e-bdc9-745135e4ddd5.png)
