### PR TITLE
Remove immediate from mailhost send in send_email_to_managers because…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,13 @@ Changelog
   [mamico]
 
 - Remove Contributor from the package permissions map
+  [folix-01]
+
 - Add configurable simultaneous bookings limit for the same user.
   [folix-01]
+
+- Remove "immediate=True" from mailhost send in send_email_to_managers because can cause multiple sends when there are conflicts.
+  [cekk]
 
 2.0.0 (2023-09-12)
 ------------------

--- a/src/redturtle/prenotazioni/events/prenotazione.py
+++ b/src/redturtle/prenotazioni/events/prenotazione.py
@@ -181,7 +181,6 @@ def send_email_to_managers(booking, event):
                     subject=subject,
                     charset="utf-8",
                     msg_type="text/html",
-                    immediate=True,
                 )
 
 


### PR DESCRIPTION
… can cause multiple sends when there are conflicts