### PR TITLE
Fix pauses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Changelog
 - Remove "immediate=True" from mailhost send in send_email_to_managers because can cause multiple sends when there are conflicts.
   [cekk]
 
+- Better handle edge-case when a booking is created inside a pause (booking created before pause set in folder config).
+  [cekk]
+
 2.0.0 (2023-09-12)
 ------------------
 

--- a/src/redturtle/prenotazioni/tests/test_move_booking_api.py
+++ b/src/redturtle/prenotazioni/tests/test_move_booking_api.py
@@ -119,7 +119,6 @@ class TestMoveBookingApi(unittest.TestCase):
                 "gate": "Gate A",
             },
         )
-
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["message"],

--- a/src/redturtle/prenotazioni/tests/test_prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/tests/test_prenotazioni_context_state.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+import unittest
+from datetime import date, datetime
+from Acquisition import aq_parent
+from plone import api
+from plone.app.testing import (
+    SITE_OWNER_NAME,
+    SITE_OWNER_PASSWORD,
+    TEST_USER_ID,
+    setRoles,
+)
+from plone.restapi.testing import RelativeSession
+from redturtle.prenotazioni.adapters.booker import IBooker
+from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_INTEGRATION_TESTING
+from redturtle.prenotazioni.tests.helpers import WEEK_TABLE_SCHEMA
+
+
+class TestPrenotazioniContextState(unittest.TestCase):
+    layer = REDTURTLE_PRENOTAZIONI_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.api_session_admin = RelativeSession(self.portal_url)
+        self.api_session_admin.headers.update({"Accept": "application/json"})
+        self.api_session_admin.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+        self.portal_url = self.portal.absolute_url()
+        self.folder_prenotazioni = api.content.create(
+            container=self.portal,
+            type="PrenotazioniFolder",
+            title="Folder",
+            description="",
+            daData=date.today(),
+            booking_types=[
+                {"name": "Type A", "duration": "30"},
+            ],
+            gates=["Gate A"],
+            week_table=WEEK_TABLE_SCHEMA,
+        )
+
+    def test_get_free_slots_skip_bookigs_inside_pause_range(self):
+        booker = IBooker(self.folder_prenotazioni)
+
+        today = date.today()
+        # need this just to have the day container
+        aq_parent(
+            booker.create(
+                {
+                    "booking_date": datetime(
+                        today.year, today.month, today.day, 10, 00
+                    ),
+                    "booking_type": "Type A",
+                    "title": "foo",
+                }
+            )
+        )
+
+        self.folder_prenotazioni.pause_table = [
+            {"day": "0", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "1", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "2", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "3", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "4", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "5", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "6", "pause_end": "1100", "pause_start": "0800"},
+            {"day": "7", "pause_end": "1100", "pause_start": "0800"},
+        ]
+
+        view = api.content.get_view(
+            context=self.folder_prenotazioni,
+            request=self.request,
+            name="prenotazioni_context_state",
+        )
+        res = view.get_free_slots(today)
+        # available slots are only arount the pause and not inside it
+        self.assertEqual(len(res["Gate A"]), 2)
+        self.assertEqual(view.get_free_slots(today)["Gate A"][0].start(), "07:00")
+        self.assertEqual(view.get_free_slots(today)["Gate A"][0].stop(), "08:00")
+        self.assertEqual(view.get_free_slots(today)["Gate A"][1].start(), "11:00")
+        self.assertEqual(view.get_free_slots(today)["Gate A"][1].stop(), "13:00")


### PR DESCRIPTION
Better handle edge-case when a booking is created inside a pause (booking created before pause set in folder config).

Old code returned also some free slots inside a pause range, because the booking inside a pause range messed up checks.