### PR TITLE
Fix gate chooser algorithm to avoid overlaps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix gate chooser algorythm to avoid overlaps. Now we randomly choose it without getting the less used one.
+  [cekk]
 
 
 2.2.4 (2023-11-30)

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -104,7 +104,7 @@ class Booker(object):
         if len(available_gates) == 0:
             return None
         if len(available_gates) == 1:
-            return available_gates.pop()
+            return available_gates[0]
         return choice(list(available_gates))
 
         # this was code to choose a less used gate that we temporary disabled

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -92,7 +92,8 @@ class Booker(object):
 
     def get_available_gate(self, booking_date, booking_expiration_date=None):
         """
-        Find which gate is free to serve this booking
+        Find which gate are free to serve this booking and choose randomly
+        one of the less busy
         """
         # XXX: per come è ora la funzione probabilmente questa condizione non è mai vera
         # if not self.prenotazioni.get_gates():
@@ -104,7 +105,23 @@ class Booker(object):
             return None
         if len(available_gates) == 1:
             return available_gates.pop()
-        return choice(self.prenotazioni.get_less_used_gates(booking_date))
+        return choice(list(available_gates))
+
+        # this was code to choose a less used gate that we temporary disabled
+        # free_slots_by_gate = self.prenotazioni.get_free_slots(booking_date)
+        # # Create a dictionary where keys is the time the gate is free, and
+        # # value is a list of gates
+        # free_time_map = {}
+        # for gate, free_slots in free_slots_by_gate.items():
+        #     if gate not in available_gates:
+        #         # this gate have already a booking for selected time, skip it
+        #         continue
+        #     free_time = sum(map(BaseSlot.__len__, free_slots))
+        #     free_time_map.setdefault(free_time, []).append(gate)
+        # # Get a random choice among the less busy ones
+        # max_free_time = max(free_time_map.keys())
+        # less_used_gates = free_time_map[max_free_time]
+        # return choice(less_used_gates)
 
     def _create(self, data, duration=-1, force_gate=""):
         """Create a Booking object

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -103,10 +103,10 @@ class Booker(object):
         )
         if len(available_gates) == 0:
             return None
-        if len(available_gates) == 1:
-            return available_gates[0]
         return choice(list(available_gates))
 
+        # if len(available_gates) == 1:
+        #    return available_gates[0]
         # this was code to choose a less used gate that we temporary disabled
         # free_slots_by_gate = self.prenotazioni.get_free_slots(booking_date)
         # # Create a dictionary where keys is the time the gate is free, and

--- a/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
@@ -923,21 +923,6 @@ class PrenotazioniContextState(BrowserView):
         good_slots.sort(key=lambda x: x.lower_value)
         return good_slots[0]
 
-    def get_less_used_gates(self, booking_date):
-        """
-        Find which gate is les busy the day of the booking
-        """
-        availability = self.get_free_slots(booking_date)
-        # Create a dictionary where keys is the time the gate is free, and
-        # value is a list of gates
-        free_time_map = {}
-        for gate, free_slots in six.iteritems(availability):
-            free_time = sum(map(BaseSlot.__len__, free_slots))
-            free_time_map.setdefault(free_time, []).append(gate)
-        # Get a random choice among the less busy one
-        max_free_time = max(free_time_map.keys())
-        return free_time_map[max_free_time]
-
     def __call__(self):
         """Return itself"""
         return self

--- a/src/redturtle/prenotazioni/tests/test_booker_choose_available_slot.py
+++ b/src/redturtle/prenotazioni/tests/test_booker_choose_available_slot.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+import unittest
+from datetime import date, datetime, timedelta
+
+import transaction
+from plone import api
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from freezegun import freeze_time
+from redturtle.prenotazioni.adapters.booker import IBooker
+
+from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_FUNCTIONAL_TESTING
+from redturtle.prenotazioni.tests.helpers import WEEK_TABLE_SCHEMA
+
+DATE_STR = "2023-12-05"  # because it's a monday
+
+
+class TestGateChooser(unittest.TestCase):
+    layer = REDTURTLE_PRENOTAZIONI_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.folder_prenotazioni = api.content.create(
+            container=self.portal,
+            type="PrenotazioniFolder",
+            title="Prenota foo",
+            daData=date.today(),
+            gates=["A", "B", "C", "D", "E"],
+            week_table=WEEK_TABLE_SCHEMA,
+        )
+
+        api.content.create(
+            type="PrenotazioneType",
+            title="Type A",
+            duration=10,
+            container=self.folder_prenotazioni,
+            gates=["all"],
+        )
+
+        api.content.transition(obj=self.folder_prenotazioni, transition="publish")
+        transaction.commit()
+
+        self.view = api.content.get_view(
+            name="prenotazioni_context_state",
+            context=self.folder_prenotazioni,
+            request=self.request,
+        )
+        self.booker = IBooker(self.folder_prenotazioni)
+
+    def create_booking(self, booking_date):
+        # need this just to have the day container
+        return self.booker.create(
+            {
+                "booking_date": booking_date,
+                "booking_type": "Type A",
+                "title": "foo",
+            }
+        )
+
+    @freeze_time(DATE_STR)
+    def test_when_all_gates_are_free_choose_one_randomly(self):
+        now = datetime.fromisoformat(date.today().isoformat())
+        available_gates = ["A", "B", "C", "D", "E"]
+        used_gates = []
+        first = self.create_booking(
+            booking_date=now + timedelta(hours=9, minutes=0),
+        )
+        available_gates = [x for x in available_gates if x != first.gate]
+
+        self.assertNotIn(first.gate, used_gates)
+        self.assertNotIn(first.gate, available_gates)
+        used_gates.append(first.gate)
+
+        second = self.create_booking(
+            booking_date=now + timedelta(hours=9, minutes=0),
+        )
+        available_gates = [x for x in available_gates if x != second.gate]
+        self.assertNotIn(second.gate, used_gates)
+        self.assertNotIn(second.gate, available_gates)
+        used_gates.append(second.gate)
+
+        third = self.create_booking(
+            booking_date=now + timedelta(hours=9, minutes=0),
+        )
+        available_gates = [x for x in available_gates if x != third.gate]
+        self.assertNotIn(third.gate, used_gates)
+        self.assertNotIn(third.gate, available_gates)
+        used_gates.append(third.gate)
+
+        fourth = self.create_booking(
+            booking_date=now + timedelta(hours=9, minutes=0),
+        )
+        available_gates = [x for x in available_gates if x != fourth.gate]
+        self.assertNotIn(fourth.gate, used_gates)
+        self.assertNotIn(fourth.gate, available_gates)
+        used_gates.append(fourth.gate)
+
+        fifth = self.create_booking(
+            booking_date=now + timedelta(hours=9, minutes=0),
+        )
+        available_gates = [x for x in available_gates if x != fifth.gate]
+        self.assertNotIn(fifth.gate, used_gates)
+        self.assertNotIn(fifth.gate, available_gates)
+        used_gates.append(fifth.gate)
+
+        self.assertEqual(len(used_gates), 5)
+        self.assertEqual(len(available_gates), 0)
+
+        self.assertIsNone(
+            self.create_booking(booking_date=now + timedelta(hours=9, minutes=0))
+        )

--- a/src/redturtle/prenotazioni/tests/test_vacation_api.py
+++ b/src/redturtle/prenotazioni/tests/test_vacation_api.py
@@ -153,7 +153,7 @@ class TestVacationgApi(unittest.TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(
             res.json()["message"],
-            "This day is not valid.",
+            "Nessuno slot creato, verificare la corretteza dei dati inseriti",
         )
 
         # add vacation when there is already a booking


### PR DESCRIPTION
Now we randomly choose it without getting the less used one.

Previous code (removed from prenotazioni_context_state) didn't worked well and returned randomly gates that shouldn't be available for that slot).