### PR TITLE
feat: @bookings fullobjects=1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add fullobjects in @bookings
+  [mamico]
 
 2.3.0 (2023-12-19)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -512,6 +512,8 @@ Parameters:
 - **userid**: The userid(basically it is the fiscalcode). Allowed to be used by users having the 'redturtle.prenotazioni: search prenotazioni' permission.
 - **booking_type**: The booking_type, available values are stored in 'redturtle.prenotazioni.booking_types' vocabulary.
 - **review_state**: The booking status, one of: 'confirmed', 'refused', 'private', 'pending'
+- **fullobjects**: If `fullobjects=1` is passed, the endpoint will return the full objects instead of a list of brains (actually the only information
+                   added is the `requirements` field. (aka `cosa_serve`).
 
 Example::
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,3 +4,7 @@
 extends =
     test-6.0.x.cfg
 #    test-5.2.x.cfg
+
+[instance]
+eggs +=
+    Products.PrintingMailHost

--- a/src/redturtle/prenotazioni/events/prenotazione.py
+++ b/src/redturtle/prenotazioni/events/prenotazione.py
@@ -93,6 +93,7 @@ def notify_on_move(booking, event):
             send_email(adapter.message)
 
 
+# TODO: sosituire con plone.api.portal.send_email
 def send_email(msg):
     if not msg:
         logger.error("Could not send email due to no message was provided")
@@ -101,7 +102,6 @@ def send_email(msg):
     host = api.portal.get_tool(name="MailHost")
     registry = getUtility(IRegistry)
     encoding = registry.get("plone.email_charset", "utf-8")
-
     host.send(msg, charset=encoding)
 
 

--- a/src/redturtle/prenotazioni/restapi/serializers/adapters/prenotazione.py
+++ b/src/redturtle/prenotazioni/restapi/serializers/adapters/prenotazione.py
@@ -95,7 +95,7 @@ class PrenotazioneSearchableItemSerializer:
     def __call__(self, *args, **kwargs):
         wf_tool = api.portal.get_tool("portal_workflow")
         status = wf_tool.getStatusOf("prenotazioni_workflow", self.prenotazione)
-        return {
+        data = {
             "title": self.prenotazione.Title(),
             "description": self.prenotazione.description,
             "booking_id": self.prenotazione.UID(),
@@ -121,3 +121,18 @@ class PrenotazioneSearchableItemSerializer:
             "company": self.prenotazione.company,
             "vacation": self.prenotazione.isVacation(),
         }
+        if kwargs.get("fullobjects", False):
+            try:
+                requirements = getMultiAdapter(
+                    (
+                        getFields(IPrenotazioneType)["requirements"],
+                        self.prenotazione.get_booking_type(),
+                        self.request,
+                    ),
+                    IFieldSerializer,
+                )()
+            except ComponentLookupError:
+                requirements = ""
+            data["requirements"] = requirements
+            data["cosa_serve"] = requirements  # BBB
+        return data

--- a/src/redturtle/prenotazioni/restapi/services/bookings/search.py
+++ b/src/redturtle/prenotazioni/restapi/services/bookings/search.py
@@ -73,13 +73,15 @@ class BookingsSearch(Service):
         return query
 
     def reply(self):
+        fullobjects = self.request.form.get("fullobjects", False) == "1"
         response = {"id": self.context.absolute_url() + "/@bookings"}
         query = self.query()
+        # XXX: `fullobjects` the correct behavior should be to use different serializers
         response["items"] = [
             getMultiAdapter(
                 (i.getObject(), self.request),
                 ISerializeToPrenotazioneSearchableItem,
-            )()
+            )(fullobjects=fullobjects)
             for i in api.portal.get_tool("portal_catalog")(**query)
         ]
 

--- a/src/redturtle/prenotazioni/restapi/services/types/get.py
+++ b/src/redturtle/prenotazioni/restapi/services/types/get.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from redturtle.prenotazioni.content.prenotazioni_folder import IPrenotazioniFolder
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.services.types.get import TypesInfo
 from zope.component import adapter
-from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface import implementer
+
+from redturtle.prenotazioni.content.prenotazioni_folder import IPrenotazioniFolder
 
 
 @implementer(IExpandableElement)

--- a/src/redturtle/prenotazioni/tests/test_add_booking.py
+++ b/src/redturtle/prenotazioni/tests/test_add_booking.py
@@ -8,19 +8,19 @@ import transaction
 from Acquisition import aq_parent
 from freezegun import freeze_time
 from plone import api
-from plone.app.testing import login
-from plone.app.testing import logout
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import login
+from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.autoform.interfaces import MODES_KEY
 from plone.restapi.testing import RelativeSession
 from zope.interface import Interface
 
 from redturtle.prenotazioni.adapters.booker import IBooker
-from redturtle.prenotazioni.exceptions.booker import BookerException
 from redturtle.prenotazioni.content.prenotazione import IPrenotazione
+from redturtle.prenotazioni.exceptions.booker import BookerException
 from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_API_FUNCTIONAL_TESTING
 from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_INTEGRATION_TESTING
 from redturtle.prenotazioni.tests.helpers import WEEK_TABLE_SCHEMA

--- a/src/redturtle/prenotazioni/tests/test_prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/tests/test_prenotazioni_context_state.py
@@ -6,8 +6,9 @@ from datetime import timedelta
 
 from Acquisition import aq_parent
 from plone import api
-from plone.app.testing import logout, login
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import login
+from plone.app.testing import logout
 from plone.app.testing import setRoles
 
 from redturtle.prenotazioni.adapters.booker import IBooker

--- a/src/redturtle/prenotazioni/tests/test_vocabularies.py
+++ b/src/redturtle/prenotazioni/tests/test_vocabularies.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
-from plone import api
 import unittest
-from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_API_FUNCTIONAL_TESTING
-from zope.component import getUtility
-from zope.schema.interfaces import IVocabularyFactory
 from datetime import date
+
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_API_FUNCTIONAL_TESTING
 
 
 class TestVocabularies(unittest.TestCase):

--- a/src/redturtle/prenotazioni/vocabularies/voc_booking_type_gates.py
+++ b/src/redturtle/prenotazioni/vocabularies/voc_booking_type_gates.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from redturtle.prenotazioni import _
-from redturtle.prenotazioni.utils import getPrenotazioniFolder
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+
+from redturtle.prenotazioni import _
+from redturtle.prenotazioni.utils import getPrenotazioniFolder
 
 
 @implementer(IVocabularyFactory)


### PR DESCRIPTION
- **fullobjects**: If `fullobjects=1` is passed, the endpoint will return the full objects instead of a list of brains (actually the only information added is the `requirements` field. (aka `cosa_serve`))