### PR TITLE
Move code generation and managers email notification into booker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Changelog
 
 - Add @id in booking serializer
   [mamico]
-
+- [BREAKING] Move code generation and managers email notification from event handlers into booker.
+  [cekk]
 
 2.4.2 (2024-01-15)
 ------------------

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -10,6 +10,7 @@ from six.moves.urllib.parse import parse_qs
 from six.moves.urllib.parse import urlparse
 from zope.annotation.interfaces import IAnnotations
 from zope.component import Interface
+from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.interface import implementer
 from ZTUtils.Lazy import LazyMap
@@ -17,11 +18,17 @@ from ZTUtils.Lazy import LazyMap
 from redturtle.prenotazioni import _
 from redturtle.prenotazioni import datetime_with_tz
 from redturtle.prenotazioni import logger
+from redturtle.prenotazioni.adapters.booking_code import IBookingCodeGenerator
 from redturtle.prenotazioni.adapters.slot import BaseSlot
+from redturtle.prenotazioni.behaviors.booking_folder.email.events import (
+    booking_folder_provides_current_behavior,
+)
 from redturtle.prenotazioni.config import VERIFIED_BOOKING
 from redturtle.prenotazioni.content.prenotazione import VACATION_TYPE
 from redturtle.prenotazioni.exceptions import BookerException
 from redturtle.prenotazioni.exceptions import BookingsLimitExceded
+from redturtle.prenotazioni.interfaces import IBookingEmailMessage
+from redturtle.prenotazioni.interfaces import IBookingNotificationSender
 from redturtle.prenotazioni.prenotazione_event import MovedPrenotazione
 from redturtle.prenotazioni.utilities.dateutils import exceedes_date_limit
 
@@ -143,6 +150,48 @@ class Booker(object):
                 msg = _("Sorry, you can not book this slot for now.")
                 raise BookerException(api.portal.translate(msg))
 
+    def generate_params(self, data, force_gate, duration):
+        # remove empty fields
+        params = {k: v for k, v in data.items() if v}
+        booking_type = params.get("booking_type", "")
+        user = api.user.get_current()
+
+        # set expiration date
+        if duration < 0:
+            # if we pass a negative duration it will be recalculated
+            duration = self.prenotazioni.get_booking_type_duration(booking_type)
+            # duration = (float(duration) / MIN_IN_DAY)
+            params["booking_expiration_date"] = params["booking_date"] + timedelta(
+                minutes=duration
+            )
+        else:
+            params["booking_expiration_date"] = params["booking_date"] + timedelta(
+                minutes=duration
+            )
+
+        # set gate
+        gate = ""
+        if force_gate:
+            gate = force_gate
+        else:
+            available_gate = self.get_available_gate(
+                params["booking_date"], params["booking_expiration_date"]
+            )
+            if available_gate:
+                gate = available_gate
+        params["gate"] = gate
+
+        # set fiscal code
+        fiscalcode = data.get("fiscalcode", "")
+
+        if not fiscalcode:
+            fiscalcode = user.getProperty("fiscalcode", "") or user.getId() or ""
+
+        if fiscalcode:
+            params["fiscalcode"] = fiscalcode.upper()
+
+        return params
+
     def _create(self, data, duration=-1, force_gate=""):
         """Create a Booking object
 
@@ -151,75 +200,75 @@ class Booker(object):
         :param force_gate: by default gates are assigned randomly except if you
                            pass this parameter.
         """
-        # remove empty fields
-        params = {k: v for k, v in data.items() if v}
+        params = self.generate_params(
+            data=data, duration=duration, force_gate=force_gate
+        )
+        if not params.get("gate", ""):
+            # no gate available
+            return
 
+        self._validate_user_limit(params)
         container = self.prenotazioni.get_container(
             params["booking_date"], create_missing=True
         )
-        booking_type = params.get("booking_type", "")
-        if duration < 0:
-            # if we pass a negative duration it will be recalculated
-            duration = self.prenotazioni.get_booking_type_duration(booking_type)
-            # duration = (float(duration) / MIN_IN_DAY)
-            booking_expiration_date = params["booking_date"] + timedelta(
-                minutes=duration
-            )
-        else:
-            booking_expiration_date = params["booking_date"] + timedelta(
-                minutes=duration
-            )
-        gate = ""
-        if not force_gate:
-            available_gate = self.get_available_gate(
-                params["booking_date"], booking_expiration_date
-            )
-            # if not available_gate: #
-            if available_gate is None:
-                # there isn't a free slot in any available gates
-                return None
-            # else assign the gate to the booking
-            gate = available_gate
-        else:
-            gate = force_gate
 
-        fiscalcode = data.get("fiscalcode", "")
-        if fiscalcode:
-            fiscalcode = fiscalcode.upper()
-        user = api.user.get_current()
-
-        if not fiscalcode:
-            fiscalcode = (
-                user.getProperty("fiscalcode", "") or user.getId() or ""
-            ).upper()  # noqa
-
-        if fiscalcode:
-            params["fiscalcode"] = fiscalcode
-            self._validate_user_limit(params)
-
-        obj = api.content.create(
+        booking = api.content.create(
             type="Prenotazione",
             container=container,
-            booking_expiration_date=booking_expiration_date,
-            gate=gate,
             **params,
         )
 
-        annotations = IAnnotations(obj)
+        # set booking_code
+        booking_code = getMultiAdapter(
+            (booking, self.context.REQUEST), IBookingCodeGenerator
+        )()
+        setattr(booking, "booking_code", booking_code)
 
+        # check verified booking
+        user = api.user.get_current()
+        annotations = IAnnotations(booking)
         annotations[VERIFIED_BOOKING] = False
-
         if not api.user.is_anonymous() and not api.user.has_permission(
             "Modify portal content", obj=container
         ):
+            fiscalcode = params.get("fiscalcode", "")
             if user.hasProperty("fiscalcode") and fiscalcode:
                 if (user.getProperty("fiscalcode") or "").upper() == fiscalcode:
-                    logger.info("Booking verified: {}".format(obj.absolute_url()))
+                    logger.info("Booking verified: {}".format(booking.absolute_url()))
                     annotations[VERIFIED_BOOKING] = True
 
-        obj.reindexObject()
-        api.content.transition(obj, "submit")
-        return obj
+        booking.reindexObject()
+        api.content.transition(booking, "submit")
+
+        # finally send email notification to managers
+        self.send_email_to_managers(booking=booking)
+
+        return booking
+
+    def send_email_to_managers(self, booking):
+        """
+        Send email notification for managers
+        """
+        if not booking_folder_provides_current_behavior(booking):
+            return
+
+        if booking.isVacation():
+            return
+        if not getattr(booking, "email_responsabile", []):
+            return
+        request = self.context.REQUEST
+        message_adapter = getMultiAdapter(
+            (booking, request),
+            IBookingEmailMessage,
+            name="notify_manager",
+        )
+        sender_adapter = getMultiAdapter(
+            (message_adapter, booking, request),
+            IBookingNotificationSender,
+            name="booking_transition_email_sender",
+        )
+
+        sender_adapter.send(force=True)
 
     def fix_container(self, booking):
         """Take a booking and move it to the right date"""

--- a/src/redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml
+++ b/src/redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml
@@ -31,11 +31,6 @@
            redturtle.prenotazioni.interfaces.IBookingReminderEvent"
       handler=".events.send_booking_reminder"
       />
-  <subscriber
-      for="redturtle.prenotazioni.content.prenotazione.IPrenotazione
-           zope.lifecycleevent.IObjectAddedEvent"
-      handler=".events.send_email_to_managers"
-      />
 
   <adapter factory=".notification_email_message.PrenotazioneAfterTransitionEmailICalMessage" />
 

--- a/src/redturtle/prenotazioni/behaviors/booking_folder/email/events.py
+++ b/src/redturtle/prenotazioni/behaviors/booking_folder/email/events.py
@@ -3,7 +3,6 @@
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
 
-from redturtle.prenotazioni import is_migration
 from redturtle.prenotazioni.interfaces import IBookingEmailMessage
 from redturtle.prenotazioni.interfaces import IBookingNotificationSender
 from redturtle.prenotazioni.utilities import handle_exception_by_log
@@ -86,29 +85,3 @@ def send_booking_reminder(context, event):
     )
 
     sender_adapter.send()
-
-
-@handle_exception_by_log
-def send_email_to_managers(booking, event):
-    if not booking_folder_provides_current_behavior(booking):
-        return
-
-    # skip email for vacation/out-of-office
-    if is_migration():
-        return
-
-    if booking.isVacation():
-        return
-    if not getattr(booking, "email_responsabile", []):
-        return
-
-    message_adapter = getMultiAdapter(
-        (booking, event), IBookingEmailMessage, name="notify_manager"
-    )
-    sender_adapter = getMultiAdapter(
-        (message_adapter, booking, getRequest()),
-        IBookingNotificationSender,
-        name="booking_transition_email_sender",
-    )
-
-    sender_adapter.send(force=True)

--- a/src/redturtle/prenotazioni/behaviors/booking_folder/email/notification_email_message.py
+++ b/src/redturtle/prenotazioni/behaviors/booking_folder/email/notification_email_message.py
@@ -203,7 +203,7 @@ class PrenotazioneManagerEmailMessage(
     PrenotazioneEventMessageICalMixIn, PrenotazioneEmailMessage
 ):
     """
-    This is not fired
+    This is not fired from an event, but used in booker.
     """
 
     def __init__(self, prenotazione, request):

--- a/src/redturtle/prenotazioni/events/configure.zcml
+++ b/src/redturtle/prenotazioni/events/configure.zcml
@@ -24,15 +24,6 @@
       />
 
   <subscriber
-      for="redturtle.prenotazioni.content.prenotazione.IPrenotazione
-           zope.lifecycleevent.IObjectCreatedEvent"
-      handler=".prenotazione.set_booking_code"
-      />
-
-  <!-- <subscriber for="redturtle.prenotazioni.prenotazione_event.IMovedPrenotazione"
-               handler=".prenotazione.reallocate_gate" /> -->
-
-  <subscriber
       for="redturtle.prenotazioni.prenotazione_event.IMovedPrenotazione"
       handler=".prenotazione.reallocate_container"
       />

--- a/src/redturtle/prenotazioni/events/prenotazione.py
+++ b/src/redturtle/prenotazioni/events/prenotazione.py
@@ -5,13 +5,9 @@ from email.utils import parseaddr
 from plone import api
 from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces.controlpanel import IMailSchema
-from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.globalrequest import getRequest
 
-from redturtle.prenotazioni import is_migration
 from redturtle.prenotazioni.adapters.booker import IBooker
-from redturtle.prenotazioni.adapters.booking_code import IBookingCodeGenerator
 
 
 def reallocate_gate(obj):
@@ -62,13 +58,3 @@ def get_mail_from_address():
     if parseaddr(mfrom)[1] != from_address:
         mfrom = from_address
     return mfrom
-
-
-def set_booking_code(booking, event):
-    """
-    set booking code. skip if we are importing old booking
-    """
-    if is_migration():
-        return
-    booking_code = getMultiAdapter((booking, getRequest()), IBookingCodeGenerator)()
-    setattr(booking, "booking_code", booking_code)

--- a/src/redturtle/prenotazioni/tests/test_add_booking.py
+++ b/src/redturtle/prenotazioni/tests/test_add_booking.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from datetime import timedelta
 
 import transaction
-from Acquisition import aq_parent
 from freezegun import freeze_time
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
@@ -432,73 +431,37 @@ class TestPrenotazioniIntegrationTesting(unittest.TestCase):
         booking_date = datetime.fromisoformat(date.today().isoformat()) + timedelta(
             days=1, hours=8
         )
-        booking_expiration_date = datetime.fromisoformat(
-            date.today().isoformat()
-        ) + timedelta(days=1, hours=8, minutes=30)
-
-        # need this just to have the day container
-        container = aq_parent(
-            self.create_booking(
-                {
-                    "booking_date": booking_date + timedelta(hours=1),
-                    "booking_type": "Type A",
-                    "title": "foo",
-                }
-            )
+        booking = self.create_booking(
+            {
+                "booking_date": booking_date + timedelta(hours=1),
+                "booking_type": "Type A",
+                "title": "foo",
+            }
         )
-
-        new_booking = api.content.create(
-            container=container,
-            type="Prenotazione",
-            title="Booking A",
-            booking_date=booking_date,
-            gate="Gate A",
-            booking_type="Type A",
-            booking_expiration_date=booking_expiration_date,
-        )
-        self.assertIsNot(new_booking.getBookingCode(), None)
-        self.assertTrue(len(new_booking.getBookingCode()) > 0)
+        self.assertIsNot(booking.getBookingCode(), None)
+        self.assertTrue(len(booking.getBookingCode()) > 0)
 
     def test_booking_code_uniqueness(self):
         booking_date = datetime.fromisoformat(date.today().isoformat()) + timedelta(
             days=1, hours=8
         )
-        booking_expiration_date = datetime.fromisoformat(
-            date.today().isoformat()
-        ) + timedelta(days=1, hours=8, minutes=30)
-        # need this just to have the day container
-        container = aq_parent(
-            self.create_booking(
-                {
-                    "booking_date": booking_date + timedelta(hours=1),
-                    "booking_type": "Type A",
-                    "title": "foo",
-                }
-            )
+        booking_1 = self.create_booking(
+            {
+                "booking_date": booking_date + timedelta(hours=1),
+                "booking_type": "Type A",
+                "title": "foo",
+            }
         )
 
-        booking_gate_A = api.content.create(
-            container=container,
-            type="Prenotazione",
-            title="Booking A",
-            booking_date=booking_date,
-            gate="Gate A",
-            booking_type="Type A",
-            booking_expiration_date=booking_expiration_date,
-        )
-        booking_gate_B = api.content.create(
-            container=container,
-            type="Prenotazione",
-            title="Booking B",
-            booking_date=booking_date,
-            gate="Gate B",
-            booking_type="Type A",
-            booking_expiration_date=booking_expiration_date,
+        booking_2 = self.create_booking(
+            {
+                "booking_date": booking_date + timedelta(hours=1, minutes=30),
+                "booking_type": "Type A",
+                "title": "foo 2",
+            }
         )
 
-        self.assertNotEqual(
-            booking_gate_A.getBookingCode(), booking_gate_B.getBookingCode()
-        )
+        self.assertNotEqual(booking_1.getBookingCode(), booking_2.getBookingCode())
 
     def test_booker_auto_confirm_manager_true_by_default(self):
         folder_prenotazioni = api.content.create(

--- a/src/redturtle/prenotazioni/upgrades.py
+++ b/src/redturtle/prenotazioni/upgrades.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
-
 import pytz
+
 from dateutil.tz.tz import tzutc
 from plone import api
 from plone.app.contentrules.actions.workflow import WorkflowAction
@@ -14,34 +14,23 @@ from plone.app.upgrade.utils import loadMigrationProfile
 from plone.app.workflow.remap import remap_workflow
 from plone.contentrules.engine.interfaces import IRuleAssignmentManager
 from plone.contentrules.engine.interfaces import IRuleStorage
+from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryUtility
 
+
+from redturtle.prenotazioni.adapters.booking_code import IBookingCodeGenerator
 from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_confirm_message_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_confirm_subject_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_move_message_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_move_subject_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_refuse_message_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_refuse_subject_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_submit_message_default_factory,
-)
-from redturtle.prenotazioni.behaviors.booking_folder.email import (
     notify_on_submit_subject_default_factory,
 )
-from redturtle.prenotazioni.events.prenotazione import set_booking_code
+
 
 logger = logging.getLogger(__name__)
 
@@ -363,7 +352,11 @@ def update_booking_code(context):
     for brain in brains:
         item = brain.getObject()
         if not getattr(item, "booking_code", None):
-            set_booking_code(item, None)
+            booking_code = getMultiAdapter(
+                (item, item.REQUEST), IBookingCodeGenerator
+            )()
+            setattr(item, "booking_code", booking_code)
+
             item.reindexObject(idxs=["SearchableText"])
             logger.info(
                 f"- [{brain.getPath()}] set booking_code to {item.booking_code}"


### PR DESCRIPTION
This is needed because in this way code generator can be better overrided, and we can use the whole acquisition when generating code.

Also we had to move manager email to booker because when raising event we haven't already set the code.