### PR TITLE
nocache for service available slots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 2.4.8 (unreleased)
 ------------------
 
+- No cache per restapi available_slots
+  [mamico]
+
 - Remove acquisition when getting version_id in **on_modify** event handler.
   [cekk]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.4.8 (unreleased)
 ------------------
 
-- No cache per restapi available_slots
+- No cache per restapi available_slots, available_slots changes frequently and anonymous users
+  need to see the updated data.
   [mamico]
 
 - Remove acquisition when getting version_id in **on_modify** event handler.

--- a/src/redturtle/prenotazioni/restapi/services/available_slots/get.py
+++ b/src/redturtle/prenotazioni/restapi/services/available_slots/get.py
@@ -20,6 +20,9 @@ class AvailableSlots(Service):
 
         If not, the search will start from current date until the end of current month.
         """
+        # XXX: nocache also for anonymous
+        self.request.response.setHeader("Cache-Control", "no-cache")
+
         prenotazioni_context_state = api.content.get_view(
             "prenotazioni_context_state",
             self.context,

--- a/src/redturtle/prenotazioni/tests/test_available_slots.py
+++ b/src/redturtle/prenotazioni/tests/test_available_slots.py
@@ -408,3 +408,9 @@ class TestAvailableSlots(unittest.TestCase):
         # self.assertEqual(len(response.json()["items"]), 4)
         type_b_len = len(response.json()["items"])
         self.assertTrue(type_a_len > type_b_len)
+
+    def test_cacheability(self):
+        response = self.api_session.get(
+            "{}/@available-slots".format(self.folder_prenotazioni.absolute_url())
+        )
+        self.assertEqual(response.headers["Cache-Control"], "no-cache")


### PR DESCRIPTION
available_slots changes frequently and anonymous users need to see the updated data.