### PR TITLE
Improved check on fiscal code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.4.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improved check on fiscal code.
+  [daniele]
 
 
 2.4.8 (2024-02-16)

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -65,11 +65,12 @@ class Booker(object):
         Raises:
             BookingsLimitExceded: User exceeded limit
         """
-
         if not self.context.max_bookings_allowed:
             return
         if data.get("booking_type", "") == "out-of-office":
             # don't limit number of out-of-office
+            return
+        if not data.get("fiscalcode", ""):
             return
         if len(
             self.search_future_bookings_by_fiscalcode(


### PR DESCRIPTION
Avoid searching bookings by fiscal code if fiscal code is not provided.