### PR TITLE
feat!: canceled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,11 @@ Changelog
 =========
 
 
-2.4.10 (unreleased)
+2.5.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- `canceled` state for booking. if an user cancel a booking, the booking is not deleted but is set to cancel state
+  [mamico]
 
 2.4.9 (2024-02-22)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = "\n\n".join(
 
 setup(
     name="redturtle.prenotazioni",
-    version="2.4.10.dev0",
+    version="2.5.0.dev0",
     description="An add-on for Plone",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/redturtle/prenotazioni/adapters/slot.py
+++ b/src/redturtle/prenotazioni/adapters/slot.py
@@ -88,19 +88,16 @@ def merge_intervals(slots):
 
 
 class ISlot(Interface):
-
     """
     Interface for a Slot object
     """
 
 
 class LowerEndpoint(int):
-
     """Lower Endpoint"""
 
 
 class UpperEndpoint(int):
-
     """Upper Endpoint"""
 
 

--- a/src/redturtle/prenotazioni/browser/folderfactories.py
+++ b/src/redturtle/prenotazioni/browser/folderfactories.py
@@ -3,7 +3,6 @@ from plone.app.content.browser.folderfactories import FolderFactoriesView as Bas
 
 
 class FolderFactoriesView(BaseView):
-
     """The folder_factories view - show addable types"""
 
     hidden_types = ("Prenotazione",)

--- a/src/redturtle/prenotazioni/browser/prenotazione_add.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_add.py
@@ -29,7 +29,6 @@ DEFAULT_REQUIRED_FIELDS = []
 
 
 class IAddForm(IPrenotazione):
-
     """
     Interface for creating a prenotazione
     """

--- a/src/redturtle/prenotazioni/browser/prenotazione_move.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_move.py
@@ -23,7 +23,6 @@ from redturtle.prenotazioni.utilities.urls import urlify
 
 
 class IMoveForm(Interface):
-
     """
     Interface for moving a prenotazione
     """
@@ -34,7 +33,6 @@ class IMoveForm(Interface):
 
 @implementer(IMoveForm)
 class MoveForm(form.Form):
-
     """Controller for moving a booking"""
 
     ignoreContext = True

--- a/src/redturtle/prenotazioni/browser/prenotazione_print.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_print.py
@@ -32,6 +32,10 @@ class PrenotazionePrint(BrowserView):
                 "confirm_booking_refused_message",
                 "Your booking has been refused.",
             ),
+            "canceled": _(
+                "confirm_booking_canceled_message",
+                "Your booking has been canceled.",
+            ),
         }
         return messages_mapping.get(review_state, "")
 

--- a/src/redturtle/prenotazioni/browser/prenotazione_print.py
+++ b/src/redturtle/prenotazioni/browser/prenotazione_print.py
@@ -11,7 +11,6 @@ from redturtle.prenotazioni.utilities.urls import urlify
 
 
 class PrenotazionePrint(BrowserView):
-
     """
     This is a view to proxy autorizzazione
     """

--- a/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
@@ -31,7 +31,6 @@ from redturtle.prenotazioni.utilities.urls import urlify
 
 
 class PrenotazioniContextState(BrowserView):
-
     """
     This is a view to for checking prenotazioni context state
     """

--- a/src/redturtle/prenotazioni/browser/prenotazioni_portal_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_portal_state.py
@@ -10,7 +10,6 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 
 class PrenotazioniPortalState(BrowserView):
-
     """Some globals for this package"""
 
     booking_types = ["Prenotazione"]

--- a/src/redturtle/prenotazioni/browser/prenotazioni_search.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_search.py
@@ -74,7 +74,6 @@ class ISearchForm(Interface):
 
 @implementer(ISearchForm)
 class SearchForm(form.Form):
-
     """ """
 
     ignoreContext = True

--- a/src/redturtle/prenotazioni/browser/vacations.py
+++ b/src/redturtle/prenotazioni/browser/vacations.py
@@ -90,7 +90,6 @@ class IVacationBooking(Interface):
 
 @implementer(IVacationBooking)
 class VacationBooking(form.Form):
-
     """
     This is a view that allows to book a gate for a certain period
     """
@@ -248,7 +247,6 @@ class VacationBooking(form.Form):
 
 
 class VacationBookingShow(BrowserView):
-
     """
     Should this functionality be confirmed?
     """

--- a/src/redturtle/prenotazioni/io_tools/__init__.py
+++ b/src/redturtle/prenotazioni/io_tools/__init__.py
@@ -1,4 +1,3 @@
-"""Top-level package for IO tools."""
 # -*- encoding: utf-8 -*-
 
 __author__ = """Mauro Amico"""

--- a/src/redturtle/prenotazioni/io_tools/rdbms.py
+++ b/src/redturtle/prenotazioni/io_tools/rdbms.py
@@ -78,9 +78,9 @@ class Storage(Base):
             body=body,
             amount=payment_data["amount"] if payment_data else None,
             notice_number=payment_data["notice_number"] if payment_data else None,
-            invalid_after_due_date=payment_data["invalid_after_due_date"]
-            if payment_data
-            else None,
+            invalid_after_due_date=(
+                payment_data["invalid_after_due_date"] if payment_data else None
+            ),
             due_date=due_date,
             status="created",
         )

--- a/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-26 23:03+0000\n"
+"POT-Creation-Date: 2024-02-27 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -603,7 +603,7 @@ msgid "booking_created"
 msgstr ""
 
 #. Default: "Your booking has been deleted."
-#: ../browser/delete_reservation.py:114
+#: ../browser/delete_reservation.py:115
 msgid "booking_deleted_success"
 msgstr ""
 
@@ -747,12 +747,17 @@ msgid "day_label"
 msgstr ""
 
 #. Default: "You can't delete your reservation; it's too late."
-#: ../browser/delete_reservation.py:138
+#: ../browser/delete_reservation.py:139
 msgid "delete_expired_booking"
 msgstr ""
 
+#. Default: "You can't delete your reservation."
+#: ../browser/delete_reservation.py:149
+msgid "delete_refused_booking"
+msgstr ""
+
 #. Default: "Delete reservation request for: ${name}"
-#: ../browser/delete_reservation.py:61
+#: ../browser/delete_reservation.py:62
 msgid "delete_reservation_request"
 msgstr ""
 
@@ -1077,12 +1082,12 @@ msgid "max_bookings_allowed_label"
 msgstr ""
 
 #. Default: "Unable to find a booking with the givend id: ${uid}."
-#: ../browser/delete_reservation.py:44
+#: ../browser/delete_reservation.py:45
 msgid "missing_booking"
 msgstr ""
 
 #. Default: "You need to provide a reservation id."
-#: ../browser/delete_reservation.py:38
+#: ../browser/delete_reservation.py:39
 msgid "missing_uid"
 msgstr ""
 
@@ -1643,6 +1648,6 @@ msgid "week_table_overrides_label"
 msgstr ""
 
 #. Default: "You tried to delete booking with a wrong action."
-#: ../browser/delete_reservation.py:97
+#: ../browser/delete_reservation.py:98
 msgid "wrong_authenticator"
 msgstr ""

--- a/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-01-08 14:15+0000\n"
+"POT-Creation-Date: 2024-02-26 23:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,1646 +14,1635 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:63
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:46
-#: redturtle/prenotazioni/browser/vacations.py:74
+#: ../browser/prenotazioni_search.py:63
+#: ../browser/stats/booking_stats.py:46
+#: ../browser/vacations.py:74
 msgid " format (YYYY-MM-DD)"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniFolder.xml
+#: ../profiles/default/types/PrenotazioniFolder.xml
 msgid "A folder that will contain booking"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "A folder that will contain booking for this day"
 msgstr ""
 
-msgid "Add"
-msgstr ""
-
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:406
-#: redturtle/prenotazioni/content/validators.py:213
+#: ../content/prenotazioni_folder.py:419
+#: ../content/validators.py:201
 msgid "Afternoon start should not be greater than end."
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
+#: ../browser/templates/prenotazione.pt:29
 msgid "Attention"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:27
+#: ../adapters/stringinterp.py:27
 msgid "Booking"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniFolder.xml
+#: ../profiles/default/types/PrenotazioniFolder.xml
 msgid "Booking Folder"
 msgstr "Prenotazioni Folder"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioneType.xml
 msgid "Booking Type"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniWeek.xml
+#: ../profiles/default/types/PrenotazioniWeek.xml
 msgid "Booking Week Folder"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniYear.xml
+#: ../profiles/default/types/PrenotazioniYear.xml
 msgid "Booking Year Folder"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:17
 msgid "Booking folder notification appio"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/email/configure.zcml:17
 msgid "Booking folder notification email"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/sms/configure.zcml:17
 msgid "Booking folder notification sms"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:44
+#: ../browser/templates/prenotazione.pt:44
 msgid "Booking for"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:27
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:27
 msgid "Booking type notification appio"
 msgstr ""
 
 #. Default: "Change date/time"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Change date/time"
 msgstr ""
 
 #. Default: "Complete address"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:43
+#: ../behaviors/booking_folder/contacts.py:43
 msgid "Complete address"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:36
+#: ../behaviors/booking_folder/contacts.py:36
 msgid "Contact PEC"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:30
+#: ../behaviors/booking_folder/contacts.py:30
 msgid "Contact fax"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:24
+#: ../behaviors/booking_folder/contacts.py:24
 msgid "Contact phone"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/configure.zcml:19
+#: ../behaviors/booking_folder/configure.zcml:18
 msgid "Contacts fields."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/configure.zcml:19
+#: ../behaviors/booking_folder/configure.zcml:18
 msgid "Contatti cartella prenotazioni"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:46
+#: ../browser/templates/prenotazioni_search.pt:46
 msgid "Content listing"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:181
+#: ../content/prenotazioni_folder.py:193
 msgid "Data fine validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:178
+#: ../content/prenotazioni_folder.py:190
 msgid "Data inizio validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:471
+#: ../content/prenotazioni_folder.py:484
 msgid "Date validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:340
+#: ../content/prenotazioni_folder.py:353
 msgid "Days booking is not allowed before"
 msgstr ""
 
-msgid "Delete"
-msgstr ""
-
 #. Default: "Descrizione Agenda"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:137
+#: ../content/prenotazioni_folder.py:149
 msgid "Descrizione Agenda"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "Edit"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:131
+#: ../behaviors/booking_folder/notifications/email/__init__.py:131
 msgid "Email from"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazione.py:175
+#: ../content/prenotazione.py:175
 msgid "Expiration date booking"
 msgstr ""
 
 #. Default: "Campo"
-#: redturtle/prenotazioni/browser/z3c_custom_widget.py:150
+#: ../browser/z3c_custom_widget.py:150
 msgid "Field"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:113
+#: ../content/prenotazioni_folder.py:112
 msgid "Friday"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:107
-#: redturtle/prenotazioni/content/prenotazione.py:170
+#: ../browser/templates/prenotazione.pt:107
+#: ../content/prenotazione.py:170
 msgid "Gate"
 msgstr ""
 
-msgid "Group"
-msgstr ""
-
 #. Default: "How to get here"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:19
+#: ../behaviors/booking_folder/contacts.py:19
 msgid "How to get here"
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:136
+#: ../content/validators.py:93
 msgid "In the same day there are overlapping intervals"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/Prenotazione.xml
 msgid "Informations about a single booking"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:138
+#: ../content/prenotazioni_folder.py:150
 msgid "Inserire il testo di presentazione dell'agenda corrente"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
+#: ../content/prenotazioni_folder.py:391
 msgid "Insert a list of email addresses that will be notified when new bookings get created."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:132
+#: ../behaviors/booking_folder/notifications/email/__init__.py:132
 msgid "Insert an email address used as \"from\" in email notifications. Leave empty to use the default from set in the site configuration."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:20
+#: ../behaviors/booking_folder/contacts.py:20
 msgid "Insert here indications on how to reach the office"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:44
+#: ../behaviors/booking_folder/contacts.py:44
 msgid "Insert here the complete office address"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:37
+#: ../behaviors/booking_folder/contacts.py:37
 msgid "Insert here the contact PEC"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:31
+#: ../behaviors/booking_folder/contacts.py:31
 msgid "Insert here the contact fax"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:25
+#: ../behaviors/booking_folder/contacts.py:25
 msgid "Insert here the contact phone"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:291
+#: ../content/prenotazioni_folder.py:303
 msgid "Insert pause table schema."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:214
+#: ../content/prenotazioni_folder.py:226
 msgid "Insert week table schema."
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:31
+#: ../configure.zcml:31
 msgid "Installs the redturtle.prenotazioni add-on."
 msgstr ""
 
-#: redturtle/prenotazioni/staging/configure.zcml:16
-msgid "Installs the redturtle.prenotazioni.staging add-on (demo site purpose only)."
+#: ../demo/configure.zcml:16
+msgid "Installs the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:328
+#: ../content/prenotazioni_folder.py:341
 msgid "Max days in the future"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:109
+#: ../content/prenotazioni_folder.py:108
 msgid "Monday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:403
-#: redturtle/prenotazioni/content/validators.py:208
+#: ../content/prenotazioni_folder.py:416
+#: ../content/validators.py:196
 msgid "Morning start should not be greater than end."
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:152
+#: ../browser/templates/prenotazione.pt:152
 msgid "Move booking"
 msgstr ""
 
-msgid "Move down"
-msgstr ""
-
-msgid "Move up"
-msgstr ""
-
-#: redturtle/prenotazioni/restapi/services/booking/vacation.py:27
+#: ../restapi/services/booking/vacation.py:27
 msgid "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:193
+#: ../content/prenotazioni_folder.py:205
 msgid "No"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:17
 msgid "Notification APPIo"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:27
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:27
 msgid "Notification APPIo for PrenotazioneType c.t."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/sms/configure.zcml:17
 msgid "Notification SMS"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/email/configure.zcml:17
 msgid "Notification email templates"
 msgstr ""
 
-#: redturtle/prenotazioni/content/pause.py:43
+#: ../content/pause.py:43
 msgid "Pause"
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:100
+#: ../content/validators.py:78
 msgid "Pause end should be greater than pause start"
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:121
+#: ../content/validators.py:122
 msgid "Pause should be included in morning slot or afternoon slot"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:290
+#: ../content/prenotazioni_folder.py:302
 msgid "Pause table"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:221
+#: ../browser/prenotazione_add.py:220
 msgid "Please provide a booking date"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/Prenotazione.xml
 msgid "Prenotazione"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "PrenotazioniDay"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniWeek.xml
+#: ../profiles/default/types/PrenotazioniWeek.xml
 msgid "PrenotazioniWeek"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniYear.xml
+#: ../profiles/default/types/PrenotazioniYear.xml
 msgid "PrenotazioniYear"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione_print.pt:129
+#: ../browser/templates/prenotazione_print.pt:129
 msgid "Print"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:77
+#: ../restapi/services/booking/add.py:122
 msgid "Required input '${field}' is missing."
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:217
+#: ../browser/prenotazione_add.py:216
 msgid "Required input is missing."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:377
+#: ../content/prenotazioni_folder.py:390
 msgid "Responsible email"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:114
+#: ../content/prenotazioni_folder.py:113
 msgid "Saturday"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:16
+#: ../browser/templates/prenotazioni_search.pt:16
 msgid "Search for"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:108
+#: ../content/prenotazioni_folder.py:107
 msgid "Select a day"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:249
-#: redturtle/prenotazioni/restapi/services/booking/add.py:58
+#: ../adapters/booker.py:299
+#: ../restapi/services/booking/add.py:64
 msgid "Sorry, this slot is not available anymore."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:292
+#: ../adapters/booker.py:342
 msgid "Sorry, this slot is not available or does not fit your booking."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:143
+#: ../adapters/booker.py:151
 msgid "Sorry, you can not book this slot for now."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazione.py:171
+#: ../content/prenotazione.py:171
 msgid "Sportello a cui presentarsi"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:115
+#: ../content/prenotazioni_folder.py:114
 msgid "Sunday"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:37
+#: ../adapters/stringinterp.py:37
 msgid "The booked date."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:50
+#: ../adapters/stringinterp.py:50
 msgid "The booked end date."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:63
+#: ../adapters/stringinterp.py:63
 msgid "The booked time."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:96
+#: ../adapters/stringinterp.py:96
 msgid "The booking code."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:291
+#: ../adapters/stringinterp.py:291
 msgid "The booking folder title"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:211
+#: ../adapters/stringinterp.py:211
 msgid "The booking human readable date"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:177
+#: ../adapters/stringinterp.py:177
 msgid "The booking office contact fax."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:167
+#: ../adapters/stringinterp.py:167
 msgid "The booking office contact pec address."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:157
+#: ../adapters/stringinterp.py:157
 msgid "The booking office contact phone."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:250
+#: ../adapters/stringinterp.py:250
 msgid "The booking operator url"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:108
+#: ../adapters/stringinterp.py:108
 msgid "The booking print url."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:259
+#: ../adapters/stringinterp.py:259
 msgid "The booking refuse message"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:280
+#: ../adapters/stringinterp.py:280
 msgid "The booking requirements url"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:75
+#: ../adapters/stringinterp.py:75
 msgid "The booking time end."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:87
+#: ../adapters/stringinterp.py:87
 msgid "The booking type."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:238
+#: ../adapters/stringinterp.py:238
 msgid "The booking url with delete token"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:199
+#: ../adapters/stringinterp.py:199
 msgid "The complete address information of the office whereuser book a reservation"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:139
+#: ../adapters/stringinterp.py:139
 msgid "The email address of the user who made the reservation."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:28
+#: ../adapters/stringinterp.py:28
 msgid "The gate booked."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:187
+#: ../adapters/stringinterp.py:187
 msgid "The information to reach the office where user book a reservation"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:130
+#: ../adapters/stringinterp.py:130
 msgid "The phone number of the user who made the reservation."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:341
+#: ../adapters/booker.py:391
 msgid "This day is not valid."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:336
+#: ../adapters/booker.py:386
 msgid "This gate has some booking schedule in this time period."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:112
+#: ../content/prenotazioni_folder.py:111
 msgid "Thursday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:110
+#: ../content/prenotazioni_folder.py:109
 msgid "Tuesday"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:40
+#: ../configure.zcml:40
 msgid "Uninstalls the redturtle.prenotazioni add-on."
 msgstr ""
 
-#: redturtle/prenotazioni/staging/configure.zcml:25
-msgid "Uninstalls the redturtle.prenotazioni.staging add-on (demo site purpose only)."
+#: ../demo/configure.zcml:25
+msgid "Uninstalls the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:113
+#: ../restapi/services/booking/add.py:158
 msgid "Unknown booking type '${booking_type}'."
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "View"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:111
+#: ../content/prenotazioni_folder.py:110
 msgid "Wednesday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:213
+#: ../content/prenotazioni_folder.py:225
 msgid "Week table"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:192
+#: ../content/prenotazioni_folder.py:204
 msgid "Yes"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:70
+#: ../restapi/services/booking/add.py:115
 msgid "You are not allowed to force the gate."
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:92
+#: ../content/validators.py:70
 msgid "You must set both start and end"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:400
-#: redturtle/prenotazioni/content/validators.py:203
+#: ../content/prenotazioni_folder.py:413
+#: ../content/validators.py:191
 msgid "You should set a start time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:396
-#: redturtle/prenotazioni/content/validators.py:195
+#: ../content/prenotazioni_folder.py:409
+#: ../content/validators.py:183
 msgid "You should set a start time for morning."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:398
-#: redturtle/prenotazioni/content/validators.py:199
+#: ../content/prenotazioni_folder.py:411
+#: ../content/validators.py:187
 msgid "You should set an end time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:394
-#: redturtle/prenotazioni/content/validators.py:191
+#: ../content/prenotazioni_folder.py:407
+#: ../content/validators.py:179
 msgid "You should set an end time for morning."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:124
+#: ../adapters/stringinterp.py:124
 msgid "[DEPRECATED] The booking print url with delete token."
 msgstr ""
 
 #. Default: "Leave empty, and this Booking Folder will never expire"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:182
+#: ../content/prenotazioni_folder.py:194
 msgid "aData_help"
 msgstr ""
 
 #. Default: "Book"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:199
-#: redturtle/prenotazioni/browser/vacations.py:207
+#: ../browser/prenotazione_add.py:198
+#: ../browser/vacations.py:206
 msgid "action_book"
 msgstr ""
 
 #. Default: "Cancel"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:252
-#: redturtle/prenotazioni/browser/prenotazione_move.py:147
-#: redturtle/prenotazioni/browser/vacations.py:232
+#: ../browser/prenotazione_add.py:251
+#: ../browser/prenotazione_move.py:145
+#: ../browser/vacations.py:231
 msgid "action_cancel"
 msgstr ""
 
 #. Default: "Move"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:122
+#: ../browser/prenotazione_move.py:120
 msgid "action_move"
 msgstr ""
 
 #. Default: "Search"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:250
+#: ../browser/prenotazioni_search.py:263
 msgid "action_search"
 msgstr ""
 
 #. Default: "End time in the afternoon"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:96
+#: ../content/prenotazioni_folder.py:95
 msgid "afternoon_end_label"
 msgstr ""
 
 #. Default: "Start time in the afternoon"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:90
+#: ../content/prenotazioni_folder.py:89
 msgid "afternoon_start_label"
 msgstr ""
 
 #. Default: "All"
-#: redturtle/prenotazioni/vocabularies/voc_booking_type_gates.py:16
+#: ../vocabularies/voc_booking_type_gates.py:16
 msgid "all"
 msgstr ""
 
 #. Default: "Automatically confirm."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:358
+#: ../content/prenotazioni_folder.py:371
 msgid "auto_confirm"
 msgstr ""
 
 #. Default: "All bookings will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:359
+#: ../content/prenotazioni_folder.py:372
 msgid "auto_confirm_help"
 msgstr ""
 
 #. Default: "Automatically confirmfor managers."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
+#: ../content/prenotazioni_folder.py:380
 msgid "auto_confirm_manager"
 msgstr ""
 
 #. Default: "All bookings created by Managers will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:368
+#: ../content/prenotazioni_folder.py:381
 msgid "auto_confirm_manager_help"
 msgstr ""
 
 #. Default: "End date should be greater than start."
-#: redturtle/prenotazioni/restapi/services/available_slots/get.py:44
+#: ../restapi/services/available_slots/get.py:48
 msgid "available_slots_wrong_dates"
 msgstr ""
 
 #. Default: "Please select a booking slot."
-#: redturtle/prenotazioni/browser/templates/week.pt:40
+#: ../browser/templates/week.pt:40
 msgid "book_it"
 msgstr ""
 
 #. Default: "Bookable time"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:454
+#: ../browser/templates/prenotazione_macros.pt:454
 msgid "bookable_time"
 msgstr ""
 
 #. Default: "${day}, ore ${booking_time}, prenotato da ${booked_by}, prenotazione: ${booking_type} durata: ${duration} minuti"
-#: redturtle/prenotazioni/browser/week.py:276
+#: ../browser/week.py:276
 msgid "booked_prenotation_message"
 msgstr ""
 
 #. Default: "Booking confirmed"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:456
+#: ../browser/templates/prenotazione_macros.pt:456
 msgid "booking_confirmed"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:231
-#: redturtle/prenotazioni/browser/vacations.py:204
+#: ../browser/prenotazione_add.py:230
+#: ../browser/vacations.py:203
 msgid "booking_created"
 msgstr ""
 
 #. Default: "Your booking has been deleted."
-#: redturtle/prenotazioni/browser/delete_reservation.py:114
+#: ../browser/delete_reservation.py:114
 msgid "booking_deleted_success"
 msgstr ""
 
 #. Default: "Booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:500
+#: ../content/prenotazioni_folder.py:513
 msgid "booking_fields_label"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_move.py:137
+#: ../browser/prenotazione_move.py:135
 msgid "booking_moved"
 msgstr ""
 
 #. Default: "Booking pending"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:458
+#: ../browser/templates/prenotazione_macros.pt:458
 msgid "booking_pending"
 msgstr ""
 
 #. Default: "Booking refused"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:460
+#: ../browser/templates/prenotazione_macros.pt:460
 msgid "booking_refused"
 msgstr ""
 
 #. Default: "Duration value"
-#: redturtle/prenotazioni/content/prenotazione_type.py:15
+#: ../content/prenotazione_type.py:15
 msgid "booking_type_duration_label"
 msgstr ""
 
 #. Default: "Name"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:427
+#: ../browser/templates/prenotazione_macros.pt:427
 msgid "booking_type_name"
 msgstr ""
 
 #. Default: "List of requirements to recieve the service"
-#: redturtle/prenotazioni/content/prenotazione_type.py:23
+#: ../content/prenotazione_type.py:23
 msgid "booking_type_requirements_help"
 msgstr ""
 
 #. Default: "Requirements"
-#: redturtle/prenotazioni/content/prenotazione_type.py:22
+#: ../content/prenotazione_type.py:22
 msgid "booking_type_requirements_labled"
 msgstr ""
 
 #. Default: "Value"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:428
+#: ../browser/templates/prenotazione_macros.pt:428
 msgid "booking_type_value"
 msgstr ""
 
 #. Default: "You may want to select another time slot to book one of these."
-#: redturtle/prenotazioni/browser/templates/booking_type_radio_widget.pt:77
+#: ../browser/templates/booking_type_radio_widget.pt:77
 msgid "booking_type_widget_suggest_reselect"
 msgstr ""
 
 #. Default: "The following tipologies will not fit the time you selected:"
-#: redturtle/prenotazioni/browser/templates/booking_type_radio_widget.pt:65
+#: ../browser/templates/booking_type_radio_widget.pt:65
 msgid "booking_type_widget_warn_unavailable"
 msgstr ""
 
 #. Default: "Set message text for all available notification events."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:257
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:257
 msgid "bookings_appio_templates_help"
 msgstr ""
 
 #. Default: "AppIO Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:253
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:253
 msgid "bookings_appio_templates_label"
 msgstr ""
 
 #. Default: "Set message text for all available notification events."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:266
+#: ../behaviors/booking_folder/notifications/email/__init__.py:266
 msgid "bookings_email_templates_help"
 msgstr ""
 
 #. Default: "Email Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:262
+#: ../behaviors/booking_folder/notifications/email/__init__.py:262
 msgid "bookings_email_templates_label"
 msgstr ""
 
 #. Default: "Booking limit({limit}) for the {booking_type} type is exceed for the current user"
-#: redturtle/prenotazioni/exceptions/booker.py:15
+#: ../exceptions/booker.py:15
 msgid "bookings_limit_exceeded_exception"
 msgstr ""
 
 #. Default: "Bookings not in agenda"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:111
+#: ../browser/templates/prenotazione_macros.pt:111
 msgid "bookings_not_in_agenda"
 msgstr ""
 
 #. Default: "Set message text for all available notification events. Remember that SMS has a 160 characters limit. Depending on your gateway service, it can split messages, if you exceed that limit."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:144
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:144
 msgid "bookings_sms_templates_help"
 msgstr ""
 
 #. Default: "SMS Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:140
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:140
 msgid "bookings_sms_templates_label"
 msgstr ""
 
 #. Default: "Busy"
-#: redturtle/prenotazioni/browser/prenotazioni_context_state.py:45
+#: ../browser/prenotazioni_context_state.py:44
 msgid "busy"
 msgstr ""
 
+#. Default: "Your booking has been canceled."
+#: ../browser/prenotazione_print.py:35
+msgid "confirm_booking_canceled_message"
+msgstr ""
+
 #. Default: "Your booking has been confirmed."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:28
+#: ../browser/prenotazione_print.py:27
 msgid "confirm_booking_confirmed_message"
 msgstr ""
 
 #. Default: "Your booking has been refused."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:32
+#: ../browser/prenotazione_print.py:31
 msgid "confirm_booking_refused_message"
 msgstr ""
 
 #. Default: "Your booking has to be confirmed by the administrators."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:24
+#: ../browser/prenotazione_print.py:23
 msgid "confirm_booking_waiting_message"
 msgstr ""
 
 #. Default: "Show here contacts information that will be used by authomatic mail system"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:49
+#: ../behaviors/booking_folder/contacts.py:49
 msgid "contacts_help"
 msgstr ""
 
 #. Default: "Contacts"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:48
+#: ../behaviors/booking_folder/contacts.py:48
 msgid "contacts_label"
 msgstr ""
 
 #. Default: "This day is not valid."
-#: redturtle/prenotazioni/browser/vacations.py:224
+#: ../browser/vacations.py:223
 msgid "day_error"
 msgstr ""
 
 #. Default: "Day of week"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:70
+#: ../content/prenotazioni_folder.py:69
 msgid "day_label"
 msgstr ""
 
 #. Default: "You can't delete your reservation; it's too late."
-#: redturtle/prenotazioni/browser/delete_reservation.py:138
+#: ../browser/delete_reservation.py:138
 msgid "delete_expired_booking"
 msgstr ""
 
 #. Default: "Delete reservation request for: ${name}"
-#: redturtle/prenotazioni/browser/delete_reservation.py:61
+#: ../browser/delete_reservation.py:61
 msgid "delete_reservation_request"
 msgstr ""
 
 #. Default: "Unique booking code"
-#: redturtle/prenotazioni/content/prenotazione.py:181
+#: ../content/prenotazione.py:181
 msgid "description_booking_code"
 msgstr ""
 
 #. Default: "If you work for a company, please specify its name."
-#: redturtle/prenotazioni/content/prenotazione.py:161
+#: ../content/prenotazione.py:161
 msgid "description_company"
 msgstr ""
 
 #. Default: "The gate that will be unavailable"
-#: redturtle/prenotazioni/browser/vacations.py:68
+#: ../browser/vacations.py:68
 msgid "description_gate"
 msgstr ""
 
 #. Default: "This text will appear in the calendar cells"
-#: redturtle/prenotazioni/browser/vacations.py:61
+#: ../browser/vacations.py:61
 msgid "description_title"
 msgstr ""
 
 #. Default: "Foreseen booking time: ${booking_time}"
-#: redturtle/prenotazioni/browser/week.py:225
+#: ../browser/week.py:225
 msgid "foreseen_booking_time"
 msgstr ""
 
 #. Default: "${booking_time}, Orario non disponibile"
-#: redturtle/prenotazioni/browser/week.py:244
+#: ../browser/week.py:244
 msgid "foreseen_busy_time"
 msgstr ""
 
-msgid "from_label"
-msgstr ""
-
 #. Default: "You should set a start range."
-#: redturtle/prenotazioni/content/validators.py:160
+#: ../content/validators.py:148
 msgid "from_month_error"
 msgstr ""
 
 #. Default: "Selected day is too big for that month for \"from\" field."
-#: redturtle/prenotazioni/content/validators.py:167
+#: ../content/validators.py:155
 msgid "from_month_too_days_error"
 msgstr ""
 
 #. Default: "Fullname"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:55
+#: ../browser/templates/prenotazione.pt:55
 msgid "fullname"
 msgstr ""
 
 #. Default: "Limit booking in the future to an amount of days in the future starting from the current day. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:329
+#: ../content/prenotazioni_folder.py:342
 msgid "futureDays"
 msgstr ""
 
 #. Default: "Put gates here (one per line)."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:351
+#: ../content/prenotazioni_folder.py:364
 msgid "gates_help"
 msgstr ""
 
 #. Default: "Gates"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:350
+#: ../content/prenotazioni_folder.py:363
 msgid "gates_label"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:156
+#: ../browser/prenotazione_add.py:155
 msgid "help_prenotazione_add"
 msgstr ""
 
 #. Default: "User will not be able to add a booking unless those fields are filled. Remember that, whatever you selected in this list, users have to supply at least one of \"Email\", \"Mobile\", or \"Telephone\""
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:164
+#: ../content/prenotazioni_folder.py:176
 msgid "help_required_booking_fields"
 msgstr ""
 
 #. Default: "States if it is not allowed to reserve a booking during the current day"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:203
+#: ../content/prenotazioni_folder.py:215
 msgid "help_same_day_booking_disallowed"
 msgstr ""
 
 #. Default: "List of available reservation type for the current agenda"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:424
+#: ../browser/templates/prenotazione_macros.pt:424
 msgid "help_tipologies"
 msgstr ""
 
 #. Default: "User will not be able to add a booking unless those fields are filled. Remember that, whatever you selected in this list, users have to supply at least one of \"Email\" or \"Telephone\""
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:146
+#: ../content/prenotazioni_folder.py:158
 msgid "help_visible_booking_fields"
 msgstr ""
 
 #. Default: "Set holidays (one for line) in DD/MM/YYYY. you can write * for the year, if this event is yearly."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:304
+#: ../content/prenotazioni_folder.py:316
 msgid "holidays_help"
 msgstr ""
 
 #. Default: "Holidays"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:303
+#: ../content/prenotazioni_folder.py:315
 msgid "holidays_label"
 msgstr ""
 
 #. Default: "Booking for ${title}"
-#: redturtle/prenotazioni/adapters/ical.py:84
+#: ../adapters/ical.py:84
 msgid "ical_booking_label"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/vacations.py:32
+#: ../browser/vacations.py:32
 msgid "invalid_date"
 msgstr ""
 
 #. Default: "Invalid email address"
-#: redturtle/prenotazioni/content/prenotazione.py:32
+#: ../content/prenotazione.py:32
 msgid "invalid_email_address"
 msgstr ""
 
 #. Default: "Invalid start or end date"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:40
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:26
+#: ../browser/prenotazioni_search.py:40
+#: ../browser/stats/booking_stats.py:26
 msgid "invalid_end:search_date"
 msgstr ""
 
 #. Default: "Invalid fiscal code"
-#: redturtle/prenotazioni/content/prenotazione.py:40
+#: ../content/prenotazione.py:40
 msgid "invalid_fiscalcode"
 msgstr ""
 
 #. Default: "Invalid phone number"
-#: redturtle/prenotazioni/content/prenotazione.py:28
+#: ../content/prenotazione.py:28
 msgid "invalid_phone_number"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/vacations.py:36
+#: ../browser/vacations.py:36
 msgid "invalid_time"
 msgstr ""
 
 #. Default: "This date is past"
-#: redturtle/prenotazioni/content/prenotazione.py:36
+#: ../content/prenotazione.py:36
 msgid "is_not_future_date"
 msgstr ""
 
 #. Default: "Booking code"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:106
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:123
-#: redturtle/prenotazioni/browser/templates/prenotazione_print.pt:110
+#: ../browser/templates/delete_reservation.pt:106
+#: ../browser/templates/prenotazione.pt:123
+#: ../browser/templates/prenotazione_print.pt:110
 msgid "label_booking_code"
 msgstr ""
 
 #. Default: "Company"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:62
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:38
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:75
+#: ../browser/templates/delete_reservation.pt:62
+#: ../browser/templates/manager_notification_mail.pt:38
+#: ../browser/templates/prenotazione.pt:75
 msgid "label_booking_company"
 msgstr ""
 
 #. Default: "Booking date"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:80
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:50
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:87
+#: ../browser/templates/delete_reservation.pt:80
+#: ../browser/templates/manager_notification_mail.pt:50
+#: ../browser/templates/prenotazione.pt:87
 msgid "label_booking_date"
 msgstr ""
 
 #. Default: "${from_date} at ${at}"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:92
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:54
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:98
+#: ../browser/templates/delete_reservation.pt:92
+#: ../browser/templates/manager_notification_mail.pt:54
+#: ../browser/templates/prenotazione.pt:98
 msgid "label_booking_date_range"
 msgstr ""
 
 #. Default: "Subject"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:41
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:74
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:46
+#: ../browser/prenotazione_add.py:40
+#: ../browser/templates/delete_reservation.pt:74
+#: ../browser/templates/manager_notification_mail.pt:46
 msgid "label_booking_description"
 msgstr ""
 
 #. Default: "Email"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:50
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:30
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:63
+#: ../browser/templates/delete_reservation.pt:50
+#: ../browser/templates/manager_notification_mail.pt:30
+#: ../browser/templates/prenotazione.pt:63
 msgid "label_booking_email"
 msgstr ""
 
 #. Default: "Fiscal code"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:68
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:42
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:79
+#: ../browser/templates/delete_reservation.pt:68
+#: ../browser/templates/manager_notification_mail.pt:42
+#: ../browser/templates/prenotazione.pt:79
 msgid "label_booking_fiscalcode"
 msgstr ""
 
 #. Default: "Phone number"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:56
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:34
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:71
+#: ../browser/templates/delete_reservation.pt:56
+#: ../browser/templates/manager_notification_mail.pt:34
+#: ../browser/templates/prenotazione.pt:71
 msgid "label_booking_phone"
 msgstr ""
 
 #. Default: "Staff notes"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:113
-#: redturtle/prenotazioni/content/prenotazione.py:186
+#: ../browser/templates/prenotazione.pt:113
+#: ../content/prenotazione.py:186
 msgid "label_booking_staff_notes"
 msgstr ""
 
 #. Default: "Booking time"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:31
-#: redturtle/prenotazioni/content/prenotazione.py:126
+#: ../browser/prenotazione_move.py:30
+#: ../content/prenotazione.py:126
 msgid "label_booking_time"
 msgstr ""
 
 #. Default: "Fullname"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:38
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:22
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:52
+#: ../browser/prenotazione_add.py:37
+#: ../browser/templates/manager_notification_mail.pt:22
+#: ../browser/templates/prenotazioni_search.pt:52
 msgid "label_booking_title"
 msgstr ""
 
 #. Default: "Booking type"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:44
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:26
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:59
+#: ../browser/templates/delete_reservation.pt:44
+#: ../browser/templates/manager_notification_mail.pt:26
+#: ../browser/templates/prenotazione.pt:59
 msgid "label_booking_type"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:293
-#: redturtle/prenotazioni/vocabularies/requirable_booking_fields.py:24
+#: ../browser/prenotazioni_search.py:306
+#: ../vocabularies/requirable_booking_fields.py:24
 msgid "label_booking_{}"
 msgstr ""
 
 #. Default: "End date"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:68
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:52
+#: ../browser/prenotazioni_search.py:68
+#: ../browser/stats/booking_stats.py:52
 msgid "label_end"
 msgstr ""
 
 #. Default: "End time"
-#: redturtle/prenotazioni/browser/vacations.py:84
+#: ../browser/vacations.py:84
 msgid "label_end_time"
 msgstr ""
 
 #. Default: "Gate"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:32
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:56
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:100
+#: ../browser/prenotazione_move.py:31
+#: ../browser/prenotazioni_search.py:56
+#: ../browser/templates/delete_reservation.pt:100
 msgid "label_gate"
 msgstr ""
 
 #. Default: "Go to the booking to see more details and manage it: ${url}"
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:65
+#: ../browser/templates/manager_notification_mail.pt:65
 msgid "label_new_booking_notify_link"
 msgstr ""
 
 #. Default: "Required booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:163
+#: ../content/prenotazioni_folder.py:175
 msgid "label_required_booking_fields"
 msgstr ""
 
 #. Default: "Disallow same day booking"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:199
+#: ../content/prenotazioni_folder.py:211
 msgid "label_same_day_booking_disallowed"
 msgstr ""
 
 #. Default: "Selected date: ${date} — Time: ${slot}"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:141
+#: ../browser/prenotazione_add.py:140
 msgid "label_selected_date"
 msgstr ""
 
 #. Default: "Start date "
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:62
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:45
-#: redturtle/prenotazioni/browser/vacations.py:73
+#: ../browser/prenotazioni_search.py:62
+#: ../browser/stats/booking_stats.py:45
+#: ../browser/vacations.py:73
 msgid "label_start"
 msgstr ""
 
 #. Default: "Start time"
-#: redturtle/prenotazioni/browser/vacations.py:78
+#: ../browser/vacations.py:78
 msgid "label_start_time"
 msgstr ""
 
 #. Default: "Text to search"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:48
+#: ../browser/prenotazioni_search.py:48
 msgid "label_text"
 msgstr ""
 
 #. Default: "Reservation types"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:423
+#: ../browser/templates/prenotazione_macros.pt:423
 msgid "label_tipologies"
 msgstr ""
 
 #. Default: "Title"
-#: redturtle/prenotazioni/browser/vacations.py:60
+#: ../browser/vacations.py:60
 msgid "label_title"
 msgstr ""
 
 #. Default: "User"
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:43
+#: ../browser/stats/booking_stats.py:43
 msgid "label_user"
 msgstr ""
 
 #. Default: "Visible booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:145
+#: ../content/prenotazioni_folder.py:157
 msgid "label_visible_booking_fields"
 msgstr ""
 
 #. Default: "Legend"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:447
+#: ../browser/templates/prenotazione_macros.pt:447
 msgid "legend"
 msgstr ""
 
 #. Default: "Short description of available action for the booking board"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:448
+#: ../browser/templates/prenotazione_macros.pt:448
 msgid "legend_description"
 msgstr ""
 
 #. Default: "The minimum value of a single slot is 5 minutes. You cannot book a reservation when the needed time exceeds the available time."
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:469
+#: ../browser/templates/prenotazione_macros.pt:469
 msgid "legend_note"
 msgstr ""
 
 #. Default: "The number of simultaneous bookings allowed for the same user."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:449
+#: ../content/prenotazioni_folder.py:462
 msgid "max_bookings_allowed_description"
 msgstr ""
 
 #. Default: "Maximum bookings number allowed"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:445
+#: ../content/prenotazioni_folder.py:458
 msgid "max_bookings_allowed_label"
 msgstr ""
 
 #. Default: "Unable to find a booking with the givend id: ${uid}."
-#: redturtle/prenotazioni/browser/delete_reservation.py:44
+#: ../browser/delete_reservation.py:44
 msgid "missing_booking"
 msgstr ""
 
 #. Default: "You need to provide a reservation id."
-#: redturtle/prenotazioni/browser/delete_reservation.py:38
+#: ../browser/delete_reservation.py:38
 msgid "missing_uid"
 msgstr ""
 
-msgid "month_label"
-msgstr ""
-
 #. Default: "End time in the morning"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:84
+#: ../content/prenotazioni_folder.py:83
 msgid "morning_end_label"
 msgstr ""
 
 #. Default: "Start time in the morning"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:79
+#: ../content/prenotazioni_folder.py:78
 msgid "morning_start_label"
 msgstr ""
 
 #. Default: "Go back to the calendar"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:260
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:192
-#: redturtle/prenotazioni/browser/templates/prenotazione_add.pt:127
+#: ../browser/prenotazioni_search.py:273
+#: ../browser/templates/prenotazione.pt:192
+#: ../browser/templates/prenotazione_add.pt:127
 msgid "move_back_message"
 msgstr ""
 
 #. Default: "Move booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:163
+#: ../browser/templates/prenotazione.pt:163
 msgid "move_booking"
 msgstr ""
 
 #. Default: "Please move this booking into a new available slot or"
-#: redturtle/prenotazioni/browser/templates/prenotazione_move.pt:39
+#: ../browser/templates/prenotazione_move.pt:39
 msgid "move_message"
 msgstr ""
 
 #. Default: "next week"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:39
+#: ../browser/templates/prenotazione_macros.pt:39
 msgid "next-week"
 msgstr ""
 
 #. Default: "Booking is not allowed before the amount of days specified. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:341
+#: ../content/prenotazioni_folder.py:354
 msgid "notBeforeDays"
 msgstr ""
 
 #. Default: "Enable AppIO notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:123
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:123
 msgid "notifications_appio_enabled_help"
 msgstr ""
 
 #. Default: "AppIO notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:122
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:122
 msgid "notifications_appio_enabled_label"
 msgstr ""
 
 #. Default: "Enable Email notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:123
+#: ../behaviors/booking_folder/notifications/email/__init__.py:123
 msgid "notifications_email_enabled_help"
 msgstr ""
 
 #. Default: "Email notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:122
+#: ../behaviors/booking_folder/notifications/email/__init__.py:122
 msgid "notifications_email_enabled_label"
 msgstr ""
 
 #. Default: "Notifications"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:508
+#: ../content/prenotazioni_folder.py:521
 msgid "notifications_label"
 msgstr ""
 
 #. Default: "Enable SMS notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:70
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:70
 msgid "notifications_sms_enabled_help"
 msgstr ""
 
 #. Default: "SMS notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:69
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:69
 msgid "notifications_sms_enabled_label"
 msgstr ""
 
 #. Default: "This is an automatic reminder about your booking on ${date} for ${booking_type}.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:111
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:111
 msgid "notify_as_reminder_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking reminder on ${booking_date}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:101
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:101
 msgid "notify_as_reminder_appio_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:231
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:231
 msgid "notify_as_reminder_appio_subject_help"
 msgstr ""
 
 #. Default: "[Reminder] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:239
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:248
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:126
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:239
+#: ../behaviors/booking_folder/notifications/email/__init__.py:248
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:126
 msgid "notify_as_reminder_message"
 msgstr ""
 
 #. Default: "This is an automatic reminder about your booking on ${date} for ${booking_type}.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:111
+#: ../behaviors/booking_folder/notifications/email/__init__.py:111
 msgid "notify_as_reminder_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:243
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:252
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:130
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:243
+#: ../behaviors/booking_folder/notifications/email/__init__.py:252
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:130
 msgid "notify_as_reminder_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: This is an automatic reminder about your booking on ${date} for ${booking_type}.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:58
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:58
 msgid "notify_as_reminder_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Reminder] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:227
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:236
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:227
+#: ../behaviors/booking_folder/notifications/email/__init__.py:236
 msgid "notify_as_reminder_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking reminder on ${booking_date}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:101
+#: ../behaviors/booking_folder/notifications/email/__init__.py:101
 msgid "notify_as_reminder_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:240
+#: ../behaviors/booking_folder/notifications/email/__init__.py:240
 msgid "notify_as_reminder_subject_help"
 msgstr ""
 
 #. Default: "Notify when confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:418
+#: ../content/prenotazioni_folder.py:431
 msgid "notify_on_confirm"
 msgstr ""
 
 #. Default: "The booking ${booking_type} for ${title} has been confirmed.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:48
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:48
 msgid "notify_on_confirm_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking of ${booking_date} at ${booking_time} was accepted"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:38
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:38
 msgid "notify_on_confirm_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:419
+#: ../content/prenotazioni_folder.py:432
 msgid "notify_on_confirm_help"
 msgstr ""
 
 #. Default: "[Confirmed] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:167
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:176
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:90
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:167
+#: ../behaviors/booking_folder/notifications/email/__init__.py:176
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:90
 msgid "notify_on_confirm_message"
 msgstr ""
 
 #. Default: "The booking ${booking_type} for ${title} has been confirmed.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:48
+#: ../behaviors/booking_folder/notifications/email/__init__.py:48
 msgid "notify_on_confirm_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been confirmed."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:171
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:180
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:94
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:171
+#: ../behaviors/booking_folder/notifications/email/__init__.py:180
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:94
 msgid "notify_on_confirm_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: Booking of ${booking_date} at ${booking_time} has been accepted.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:28
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:28
 msgid "notify_on_confirm_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Confirm] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:155
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:164
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:155
+#: ../behaviors/booking_folder/notifications/email/__init__.py:164
 msgid "notify_on_confirm_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking of ${booking_date} at ${booking_time} was accepted"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:38
+#: ../behaviors/booking_folder/notifications/email/__init__.py:38
 msgid "notify_on_confirm_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been confirmed."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:159
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:168
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:159
+#: ../behaviors/booking_folder/notifications/email/__init__.py:168
 msgid "notify_on_confirm_subject_help"
 msgstr ""
 
 #. Default: "Notify when moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:427
+#: ../content/prenotazioni_folder.py:440
 msgid "notify_on_move"
 msgstr ""
 
 #. Default: "The booking scheduling for ${booking_type} was modified.<br/><br/>The new one is on ${booking_date} at ${booking_time}.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:69
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:69
 msgid "notify_on_move_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking date modified for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:59
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:59
 msgid "notify_on_move_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:428
+#: ../content/prenotazioni_folder.py:441
 msgid "notify_on_move_help"
 msgstr ""
 
 #. Default: "[Move] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:191
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:200
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:102
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:191
+#: ../behaviors/booking_folder/notifications/email/__init__.py:200
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:102
 msgid "notify_on_move_message"
 msgstr ""
 
 #. Default: "The booking scheduling for ${booking_type} was modified.<br/><br/>The new one is on ${booking_date} at ${booking_time}.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:69
+#: ../behaviors/booking_folder/notifications/email/__init__.py:69
 msgid "notify_on_move_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been moved."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:195
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:204
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:106
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:195
+#: ../behaviors/booking_folder/notifications/email/__init__.py:204
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:106
 msgid "notify_on_move_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: The booking scheduling for ${booking_type} was modified.\nThe new one is on ${booking_date} at ${booking_time}.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:38
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:38
 msgid "notify_on_move_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Move] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:179
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:188
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:179
+#: ../behaviors/booking_folder/notifications/email/__init__.py:188
 msgid "notify_on_move_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking date modified for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:59
+#: ../behaviors/booking_folder/notifications/email/__init__.py:59
 msgid "notify_on_move_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been moved."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:183
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:192
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:183
+#: ../behaviors/booking_folder/notifications/email/__init__.py:192
 msgid "notify_on_move_subject_help"
 msgstr ""
 
 #. Default: "Notify when rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
+#: ../content/prenotazioni_folder.py:449
 msgid "notify_on_refuse"
 msgstr ""
 
 #. Default: "The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:91
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:91
 msgid "notify_on_refuse_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking refused for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:81
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:81
 msgid "notify_on_refuse_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:437
+#: ../content/prenotazioni_folder.py:450
 msgid "notify_on_refuse_help"
 msgstr ""
 
 #. Default: "[Refuse] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:215
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:224
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:114
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:215
+#: ../behaviors/booking_folder/notifications/email/__init__.py:224
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:114
 msgid "notify_on_refuse_message"
 msgstr ""
 
 #. Default: "The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:91
+#: ../behaviors/booking_folder/notifications/email/__init__.py:91
 msgid "notify_on_refuse_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:219
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:228
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:118
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:219
+#: ../behaviors/booking_folder/notifications/email/__init__.py:228
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:118
 msgid "notify_on_refuse_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:48
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:48
 msgid "notify_on_refuse_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Refuse] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:203
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:212
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:203
+#: ../behaviors/booking_folder/notifications/email/__init__.py:212
 msgid "notify_on_refuse_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking refused for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:81
+#: ../behaviors/booking_folder/notifications/email/__init__.py:81
 msgid "notify_on_refuse_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:207
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:216
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:207
+#: ../behaviors/booking_folder/notifications/email/__init__.py:216
 msgid "notify_on_refuse_subject_help"
 msgstr ""
 
 #. Default: "Notify when created."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:409
+#: ../content/prenotazioni_folder.py:422
 msgid "notify_on_submit"
 msgstr ""
 
 #. Default: "Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.<br/><br/>You can see details and print a reminder following this [${booking_print_url}](link)."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:28
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:28
 msgid "notify_on_submit_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking created"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:18
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:18
 msgid "notify_on_submit_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been created. If auto-confirm flag is selected and confirm notify is selected, this one will be ignored."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:410
+#: ../content/prenotazioni_folder.py:423
 msgid "notify_on_submit_help"
 msgstr ""
 
 #. Default: "[Created] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:143
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:152
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:78
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:143
+#: ../behaviors/booking_folder/notifications/email/__init__.py:152
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:78
 msgid "notify_on_submit_message"
 msgstr ""
 
 #. Default: "Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:28
+#: ../behaviors/booking_folder/notifications/email/__init__.py:28
 msgid "notify_on_submit_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been created."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:147
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:156
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:82
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:147
+#: ../behaviors/booking_folder/notifications/email/__init__.py:156
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:82
 msgid "notify_on_submit_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:18
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:18
 msgid "notify_on_submit_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Created] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:131
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:140
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:131
+#: ../behaviors/booking_folder/notifications/email/__init__.py:140
 msgid "notify_on_submit_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking created"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:18
+#: ../behaviors/booking_folder/notifications/email/__init__.py:18
 msgid "notify_on_submit_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been created."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:135
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:144
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:135
+#: ../behaviors/booking_folder/notifications/email/__init__.py:144
 msgid "notify_on_submit_subject_help"
 msgstr ""
 
 #. Default: "Pause end"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:125
+#: ../content/prenotazioni_folder.py:124
 msgid "pause_end_label"
 msgstr ""
 
 #. Default: "Pause start"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:120
+#: ../content/prenotazioni_folder.py:119
 msgid "pause_start_label"
 msgstr ""
 
 #. Default: "Please select a time slot"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:280
+#: ../browser/prenotazione_add.py:279
 msgid "please_pick_a_date"
 msgstr ""
 
 #. Default: "${day}, ore ${booking_time}"
-#: redturtle/prenotazioni/browser/week.py:256
+#: ../browser/week.py:256
 msgid "prenotation_slot_message"
 msgstr ""
 
 #. Default: "prenotazioni_search"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "prenotazioni_search"
 msgstr ""
 
 #. Default: "previous week"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:14
+#: ../browser/templates/prenotazione_macros.pt:14
 msgid "previous-week"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:31
+#: ../configure.zcml:31
 msgid "redturtle.prenotazioni"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:48
+#: ../configure.zcml:48
 msgid "redturtle.prenotazioni (to_1500)"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:40
-#: redturtle/prenotazioni/staging/configure.zcml:25
+#: ../configure.zcml:56
+msgid "redturtle.prenotazioni (to_2005)"
+msgstr ""
+
+#: ../configure.zcml:40
+#: ../demo/configure.zcml:25
 msgid "redturtle.prenotazioni (uninstall)"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:48
+#: ../configure.zcml:48
 msgid "redturtle.prenotazioni to 1500."
 msgstr ""
 
-#: redturtle/prenotazioni/staging/configure.zcml:16
-msgid "redturtle.prenotazioni.staging"
+#: ../configure.zcml:56
+msgid "redturtle.prenotazioni to 2005."
+msgstr ""
+
+#: ../demo/configure.zcml:16
+msgid "redturtle.prenotazioni.demo"
 msgstr ""
 
 #. Default: "The booking state is \"refused\". If you change it, the booking time may conflict with another one."
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:30
+#: ../browser/templates/prenotazione.pt:30
 msgid "refused-review-state-warning"
 msgstr ""
 
 #. Default: "Reject booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:176
+#: ../browser/templates/prenotazione.pt:176
 msgid "reject_booking"
 msgstr ""
 
 #. Default: "Set how many days before of a booking date the user will be notified about it."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:461
+#: ../content/prenotazioni_folder.py:474
 msgid "reminder_notification_gap_description"
 msgstr ""
 
 #. Default: "Booking reminder days"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:457
+#: ../content/prenotazioni_folder.py:470
 msgid "reminder_notification_gap_label"
 msgstr ""
 
 #. Default: "Code"
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:58
+#: ../browser/templates/prenotazioni_search.pt:58
 msgid "reservation_code"
 msgstr ""
 
 #. Default: "Reservation date"
-#: redturtle/prenotazioni/browser/templates/prenotazione_move.pt:33
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:57
+#: ../browser/templates/prenotazione_move.pt:33
+#: ../browser/templates/prenotazioni_search.pt:57
 msgid "reservation_date"
 msgstr ""
 
 #. Default: "Booking request for: ${name}"
-#: redturtle/prenotazioni/browser/prenotazione_print.py:44
+#: ../browser/prenotazione_print.py:47
 msgid "reservation_request"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:30
+#: ../browser/templates/prenotazione_macros.pt:30
 msgid "resize"
 msgstr ""
 
 #. Default: "items matching your search terms."
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:30
+#: ../browser/templates/prenotazioni_search.pt:30
 msgid "result_number"
 msgstr ""
 
 #. Default: "You need to provide a booking date to get the schema and available types."
-#: redturtle/prenotazioni/restapi/services/booking_schema/get.py:71
+#: ../restapi/services/booking_schema/get.py:71
 msgid "schema_missing_date"
 msgstr ""
 
 #. Default: "Search by gate"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:465
+#: ../browser/templates/prenotazione_macros.pt:465
 msgid "search-by-gate"
 msgstr ""
 
 #. Default: "Search result"
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:12
+#: ../browser/templates/prenotazioni_search.pt:12
 msgid "search_result_message"
 msgstr ""
 
 #. Default: "seleziona l'opzione desiderata dal gruppo di radio button seguente"
-#: redturtle/prenotazioni/browser/z3c_custom_widget.py:153
+#: ../browser/z3c_custom_widget.py:153
 msgid "select-option"
 msgstr ""
 
 #. Default: "AppIO service code related to the current booking type"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:293
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:293
 msgid "service_code_help"
 msgstr ""
 
 #. Default: "AppIO service code."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:289
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:289
 msgid "service_code_label"
 msgstr ""
 
 #. Default: "This gate has some booking schedule in this time period."
-#: redturtle/prenotazioni/browser/vacations.py:217
+#: ../browser/vacations.py:216
 msgid "slot_conflict_error"
 msgstr ""
 
 #. Default: "You cannot book any booking_type at this time"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:284
+#: ../browser/prenotazione_add.py:283
 msgid "time_slot_to_short"
 msgstr ""
 
-msgid "to_label"
-msgstr ""
-
 #. Default: "You should set an end range."
-#: redturtle/prenotazioni/content/validators.py:175
+#: ../content/validators.py:163
 msgid "to_month_error"
 msgstr ""
 
 #. Default: "Selected day is too big for that month for \"to\" field."
-#: redturtle/prenotazioni/content/validators.py:182
+#: ../content/validators.py:170
 msgid "to_month_too_days_error"
 msgstr ""
 
 #. Default: "You can't add a booking with type '${booking_type}'."
-#: redturtle/prenotazioni/restapi/services/booking/add.py:89
+#: ../restapi/services/booking/add.py:134
 msgid "unauthorized_add_vacation"
 msgstr ""
 
 #. Default: "Unbookable time"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:452
+#: ../browser/templates/prenotazione_macros.pt:452
 msgid "unbookable_time"
 msgstr ""
 
 #. Default: "vacation_booking"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "vacation_booking"
 msgstr ""
 
 #. Default: "View booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:143
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:463
+#: ../browser/templates/prenotazione.pt:143
+#: ../browser/templates/prenotazione_macros.pt:463
 msgid "view_booking"
 msgstr ""
 
 #. Default: "Insert here week schema for some custom date intervals."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:281
+#: ../content/prenotazioni_folder.py:293
 msgid "week_table_overrides_help"
 msgstr ""
 
 #. Default: "Week table overrides"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:280
+#: ../content/prenotazioni_folder.py:292
 msgid "week_table_overrides_label"
 msgstr ""
 
 #. Default: "You tried to delete booking with a wrong action."
-#: redturtle/prenotazioni/browser/delete_reservation.py:97
+#: ../browser/delete_reservation.py:97
 msgid "wrong_authenticator"
 msgstr ""

--- a/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-01-08 14:15+0000\n"
+"POT-Creation-Date: 2024-02-26 23:03+0000\n"
 "PO-Revision-Date: 2014-05-27 17:36+0200\n"
 "Last-Translator: Alessandro Pisa <alessandro.pisa@redturtle.it>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -16,1298 +16,1282 @@ msgstr ""
 "Language: en_US\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:63
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:46
-#: redturtle/prenotazioni/browser/vacations.py:74
+#: ../browser/prenotazioni_search.py:63
+#: ../browser/stats/booking_stats.py:46
+#: ../browser/vacations.py:74
 msgid " format (YYYY-MM-DD)"
 msgstr "Formato (AAAA-MM-GG)"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniFolder.xml
+#: ../profiles/default/types/PrenotazioniFolder.xml
 msgid "A folder that will contain booking"
 msgstr "Una cartella che conterrà le prenotazioni"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "A folder that will contain booking for this day"
 msgstr "Una cartella che conterrà le prenotazioni per questo day"
 
-msgid "Add"
-msgstr "Aggiungi"
-
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:406
-#: redturtle/prenotazioni/content/validators.py:213
+#: ../content/prenotazioni_folder.py:419
+#: ../content/validators.py:201
 msgid "Afternoon start should not be greater than end."
 msgstr "L'orario di inizio del pomeriggio non può essere successivo alla chiusura."
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
+#: ../browser/templates/prenotazione.pt:29
 msgid "Attention"
 msgstr "Attenzione!"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:27
+#: ../adapters/stringinterp.py:27
 msgid "Booking"
 msgstr "Prenotazioni"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniFolder.xml
+#: ../profiles/default/types/PrenotazioniFolder.xml
 msgid "Booking Folder"
 msgstr "Cartella prenotazioni"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioneType.xml
 msgid "Booking Type"
 msgstr "Tipologia Prenotazione"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniWeek.xml
+#: ../profiles/default/types/PrenotazioniWeek.xml
 msgid "Booking Week Folder"
 msgstr "Cartella settimana prenotazioni"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniYear.xml
+#: ../profiles/default/types/PrenotazioniYear.xml
 msgid "Booking Year Folder"
 msgstr "Cartella anno prenotazioni"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:17
 msgid "Booking folder notification appio"
 msgstr "Notifiche AppIo"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/email/configure.zcml:17
 msgid "Booking folder notification email"
 msgstr "Notifiche email"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/sms/configure.zcml:17
 msgid "Booking folder notification sms"
 msgstr "Notifiche SMS"
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:44
+#: ../browser/templates/prenotazione.pt:44
 msgid "Booking for"
 msgstr "Prenotazione di"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:27
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:27
 msgid "Booking type notification appio"
 msgstr "Notifiche AppIO per tipologia prenotazione"
 
 #. Default: "Change date/time"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Change date/time"
 msgstr "Cambia la data di prenotazione."
 
 #. Default: "Complete address"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:43
+#: ../behaviors/booking_folder/contacts.py:43
 msgid "Complete address"
 msgstr "Indirizzo completo"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:36
+#: ../behaviors/booking_folder/contacts.py:36
 msgid "Contact PEC"
 msgstr "Indirizzo PEC per il contatto"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:30
+#: ../behaviors/booking_folder/contacts.py:30
 msgid "Contact fax"
 msgstr "Numero di FAX per il contatto"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:24
+#: ../behaviors/booking_folder/contacts.py:24
 msgid "Contact phone"
 msgstr "Numero di telefono per il contatto"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/configure.zcml:19
+#: ../behaviors/booking_folder/configure.zcml:18
 msgid "Contacts fields."
 msgstr "Campi di contatto."
 
-#: redturtle/prenotazioni/behaviors/booking_folder/configure.zcml:19
+#: ../behaviors/booking_folder/configure.zcml:18
 msgid "Contatti cartella prenotazioni"
 msgstr "Contatti cartella prenotazioni"
 
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:46
+#: ../browser/templates/prenotazioni_search.pt:46
 msgid "Content listing"
 msgstr "Elenco dei contenuti"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:181
+#: ../content/prenotazioni_folder.py:193
 msgid "Data fine validità"
 msgstr "Data fine validità"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:178
+#: ../content/prenotazioni_folder.py:190
 msgid "Data inizio validità"
 msgstr "Data inizio validità"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:471
+#: ../content/prenotazioni_folder.py:484
 msgid "Date validità"
 msgstr "Date Validità"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:340
+#: ../content/prenotazioni_folder.py:353
 msgid "Days booking is not allowed before"
 msgstr "Giorni da cui si può effettuare una prenotazione"
 
-msgid "Delete"
-msgstr "Cancella"
-
 #. Default: "Descrizione Agenda"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:137
+#: ../content/prenotazioni_folder.py:149
 msgid "Descrizione Agenda"
 msgstr "Descrizione Agenda"
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "Edit"
 msgstr "Modifica"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:131
+#: ../behaviors/booking_folder/notifications/email/__init__.py:131
 msgid "Email from"
 msgstr "Mittente"
 
-#: redturtle/prenotazioni/content/prenotazione.py:175
+#: ../content/prenotazione.py:175
 msgid "Expiration date booking"
 msgstr "Data scandenza prenotazione"
 
 #. Default: "Campo"
-#: redturtle/prenotazioni/browser/z3c_custom_widget.py:150
+#: ../browser/z3c_custom_widget.py:150
 msgid "Field"
 msgstr "Campo"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:113
+#: ../content/prenotazioni_folder.py:112
 msgid "Friday"
 msgstr "Venerdì"
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:107
-#: redturtle/prenotazioni/content/prenotazione.py:170
+#: ../browser/templates/prenotazione.pt:107
+#: ../content/prenotazione.py:170
 msgid "Gate"
 msgstr "Postazione"
 
-msgid "Group"
-msgstr "Gruppo"
-
 #. Default: "How to get here"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:19
+#: ../behaviors/booking_folder/contacts.py:19
 msgid "How to get here"
 msgstr "Indicazioni su come raggiungere l'ufficio"
 
-#: redturtle/prenotazioni/content/validators.py:136
+#: ../content/validators.py:93
 msgid "In the same day there are overlapping intervals"
 msgstr "Ci sono pause che si sovrappongono nello stesso giorno"
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/Prenotazione.xml
 msgid "Informations about a single booking"
 msgstr "Informazioni relativa ad una singola prenotazione"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:138
+#: ../content/prenotazioni_folder.py:150
 msgid "Inserire il testo di presentazione dell'agenda corrente"
 msgstr "Inserire il testo di presentazione dell'agenda corrente"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
+#: ../content/prenotazioni_folder.py:391
 msgid "Insert a list of email addresses that will be notified when new bookings get created."
 msgstr "Inserisci una lista di indirizzi email che verranno notificati alla creazione di una nuova prenotazione."
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:132
+#: ../behaviors/booking_folder/notifications/email/__init__.py:132
 msgid "Insert an email address used as \"from\" in email notifications. Leave empty to use the default from set in the site configuration."
 msgstr "Inserisci un indirizzo email da usare come mittente per queste notifiche. Se vuoto, verrà utilizzato l'indirizzo mitente impostato nel sito."
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:20
+#: ../behaviors/booking_folder/contacts.py:20
 msgid "Insert here indications on how to reach the office"
 msgstr "Scrivere le indicazioni complete per raggiungere l'ufficio"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:44
+#: ../behaviors/booking_folder/contacts.py:44
 msgid "Insert here the complete office address"
 msgstr "Inserire l'indirizzo dell'ufficio"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:37
+#: ../behaviors/booking_folder/contacts.py:37
 msgid "Insert here the contact PEC"
 msgstr "Inserire l'indirizzo di posta PEC per contattare l'ufficio"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:31
+#: ../behaviors/booking_folder/contacts.py:31
 msgid "Insert here the contact fax"
 msgstr "Inserire il numero di FAX per per contattare l'ufficio"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:25
+#: ../behaviors/booking_folder/contacts.py:25
 msgid "Insert here the contact phone"
 msgstr "Inserire il numero di telefono per contattare l'ufficio"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:291
+#: ../content/prenotazioni_folder.py:303
 msgid "Insert pause table schema."
 msgstr "Inserisci le pause giornaliere. Esistono tre tipi di vincolo: una data di termine pausa deve essere maggiore della data di inizio pausa; le pause nello stesso giorno non possono sovrapporsi; le pause devono essere comprese fra l'inizio e la fine dell'orario di lavoro."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:214
+#: ../content/prenotazioni_folder.py:226
 msgid "Insert week table schema."
 msgstr "Compila la tabella degli orari della settimana."
 
-#: redturtle/prenotazioni/configure.zcml:31
+#: ../configure.zcml:31
 msgid "Installs the redturtle.prenotazioni add-on."
 msgstr "Install redturtle.prenotazioni"
 
-#: redturtle/prenotazioni/staging/configure.zcml:16
-msgid "Installs the redturtle.prenotazioni.staging add-on (demo site purpose only)."
-msgstr "Installa redturtle.prenotazioni.staging (sito di demo)."
+#: ../demo/configure.zcml:16
+msgid "Installs the redturtle.prenotazioni.demo add-on (demo site purpose only)."
+msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:328
+#: ../content/prenotazioni_folder.py:341
 msgid "Max days in the future"
 msgstr "Massimi giorni nel futuro"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:109
+#: ../content/prenotazioni_folder.py:108
 msgid "Monday"
 msgstr "Lunedì"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:403
-#: redturtle/prenotazioni/content/validators.py:208
+#: ../content/prenotazioni_folder.py:416
+#: ../content/validators.py:196
 msgid "Morning start should not be greater than end."
 msgstr "L'orario di inizio della mattina non può essere successivo alla fine."
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:152
+#: ../browser/templates/prenotazione.pt:152
 msgid "Move booking"
 msgstr "Sposta la prenotazione"
 
-msgid "Move down"
-msgstr "Sposta su"
-
-msgid "Move up"
-msgstr "Sposta giù"
-
-#: redturtle/prenotazioni/restapi/services/booking/vacation.py:27
+#: ../restapi/services/booking/vacation.py:27
 msgid "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 msgstr "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:193
+#: ../content/prenotazioni_folder.py:205
 msgid "No"
 msgstr "No"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:17
 msgid "Notification APPIo"
 msgstr "Notifiche AppIo"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:27
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:27
 msgid "Notification APPIo for PrenotazioneType c.t."
 msgstr "Notifiche AppIo per i content-type PrenotazioneType"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/sms/configure.zcml:17
 msgid "Notification SMS"
 msgstr "Notifiche SMS"
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/email/configure.zcml:17
 msgid "Notification email templates"
 msgstr "Template per notifiche email"
 
-#: redturtle/prenotazioni/content/pause.py:43
+#: ../content/pause.py:43
 msgid "Pause"
 msgstr "Pausa"
 
-#: redturtle/prenotazioni/content/validators.py:100
+#: ../content/validators.py:78
 msgid "Pause end should be greater than pause start"
 msgstr "Il termine della pausa non può avvenire prima del suo inizio"
 
-#: redturtle/prenotazioni/content/validators.py:121
+#: ../content/validators.py:122
 msgid "Pause should be included in morning slot or afternoon slot"
 msgstr "Le pause devono essere comprese tra l'orario di inizio o di termine dell'intervallo di orari di lavoro"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:290
+#: ../content/prenotazioni_folder.py:302
 msgid "Pause table"
 msgstr "Schedulazione delle pause"
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:221
+#: ../browser/prenotazione_add.py:220
 msgid "Please provide a booking date"
 msgstr "Per favore seleziona una data."
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/Prenotazione.xml
 msgid "Prenotazione"
 msgstr "Prenotazione"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "PrenotazioniDay"
 msgstr "PrenotazioniDay"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniWeek.xml
+#: ../profiles/default/types/PrenotazioniWeek.xml
 msgid "PrenotazioniWeek"
 msgstr "PrenotazioniWeek"
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniYear.xml
+#: ../profiles/default/types/PrenotazioniYear.xml
 msgid "PrenotazioniYear"
 msgstr "PrenotazioniYear"
 
-#: redturtle/prenotazioni/browser/templates/prenotazione_print.pt:129
+#: ../browser/templates/prenotazione_print.pt:129
 msgid "Print"
 msgstr "Stampa"
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:77
+#: ../restapi/services/booking/add.py:122
 msgid "Required input '${field}' is missing."
 msgstr "Campo obbligatorio '${field}' mancante."
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:217
+#: ../browser/prenotazione_add.py:216
 msgid "Required input is missing."
 msgstr "Manca l'input obbligatorio."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:377
+#: ../content/prenotazioni_folder.py:390
 msgid "Responsible email"
 msgstr "Email del responsabile"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:114
+#: ../content/prenotazioni_folder.py:113
 msgid "Saturday"
 msgstr "Sabato"
 
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:16
+#: ../browser/templates/prenotazioni_search.pt:16
 msgid "Search for"
 msgstr "Parametri di ricerca"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:108
+#: ../content/prenotazioni_folder.py:107
 msgid "Select a day"
 msgstr "Seleziona un giorno"
 
-#: redturtle/prenotazioni/adapters/booker.py:249
-#: redturtle/prenotazioni/restapi/services/booking/add.py:58
+#: ../adapters/booker.py:299
+#: ../restapi/services/booking/add.py:64
 msgid "Sorry, this slot is not available anymore."
 msgstr "Ci dispiace, ma questo intervallo di tempo non è più disponibile"
 
-#: redturtle/prenotazioni/adapters/booker.py:292
+#: ../adapters/booker.py:342
 msgid "Sorry, this slot is not available or does not fit your booking."
 msgstr "Ci dispiace questo intervallo di tempo non è disponibile o non è adatto alla tua prenotazione."
 
-#: redturtle/prenotazioni/adapters/booker.py:143
+#: ../adapters/booker.py:151
 msgid "Sorry, you can not book this slot for now."
 msgstr "Ci dispiace, ma questo intervallo di tempo non è al momento disponibile"
 
-#: redturtle/prenotazioni/content/prenotazione.py:171
+#: ../content/prenotazione.py:171
 msgid "Sportello a cui presentarsi"
 msgstr "Postazione a cui presentarsi"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:115
+#: ../content/prenotazioni_folder.py:114
 msgid "Sunday"
 msgstr "Domenica"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:37
+#: ../adapters/stringinterp.py:37
 msgid "The booked date."
 msgstr "La data di prenotazione."
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:50
+#: ../adapters/stringinterp.py:50
 msgid "The booked end date."
 msgstr "La data di fine prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:63
+#: ../adapters/stringinterp.py:63
 msgid "The booked time."
 msgstr "L'orario di prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:96
+#: ../adapters/stringinterp.py:96
 msgid "The booking code."
 msgstr "Il codice di prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:291
+#: ../adapters/stringinterp.py:291
 msgid "The booking folder title"
 msgstr "Il titolo della cartella prenotazioni"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:211
+#: ../adapters/stringinterp.py:211
 msgid "The booking human readable date"
 msgstr "La data di prenotazione in formato leggibile"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:177
+#: ../adapters/stringinterp.py:177
 msgid "The booking office contact fax."
 msgstr "Il Fax per contattare l'ufficio"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:167
+#: ../adapters/stringinterp.py:167
 msgid "The booking office contact pec address."
 msgstr "L'indirizzo PEC per contattare l'ufficio"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:157
+#: ../adapters/stringinterp.py:157
 msgid "The booking office contact phone."
 msgstr "Il telefono per contattare l'ufficio"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:250
+#: ../adapters/stringinterp.py:250
 msgid "The booking operator url"
 msgstr "L'url della prenotazione per gli operatori"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:108
+#: ../adapters/stringinterp.py:108
 msgid "The booking print url."
 msgstr "L'url per stampare la prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:259
+#: ../adapters/stringinterp.py:259
 msgid "The booking refuse message"
 msgstr "Il messaggio di rifiuto della prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:280
+#: ../adapters/stringinterp.py:280
 msgid "The booking requirements url"
 msgstr "L'url per il cosa server"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:75
+#: ../adapters/stringinterp.py:75
 msgid "The booking time end."
 msgstr "L'orario di fine prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:87
+#: ../adapters/stringinterp.py:87
 msgid "The booking type."
 msgstr "La tipologia della prenotazione."
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:238
+#: ../adapters/stringinterp.py:238
 msgid "The booking url with delete token"
 msgstr "L'url della prenotazione con il token per la cancellazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:199
+#: ../adapters/stringinterp.py:199
 msgid "The complete address information of the office whereuser book a reservation"
 msgstr "L'indirizzo completo dell'ufficio presso cui si prenota"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:139
+#: ../adapters/stringinterp.py:139
 msgid "The email address of the user who made the reservation."
 msgstr "L'indirizzo email dell'utente che ha fatto la prenotazione"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:28
+#: ../adapters/stringinterp.py:28
 msgid "The gate booked."
 msgstr "La postazione prenotata."
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:187
+#: ../adapters/stringinterp.py:187
 msgid "The information to reach the office where user book a reservation"
 msgstr "Le informazioni per raggiungere l'ufficio presso cui si prenota"
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:130
+#: ../adapters/stringinterp.py:130
 msgid "The phone number of the user who made the reservation."
 msgstr "Il numero di telefono di chi ha prenotato"
 
-#: redturtle/prenotazioni/adapters/booker.py:341
+#: ../adapters/booker.py:391
 msgid "This day is not valid."
 msgstr "Il giorno inserito non è valido."
 
-#: redturtle/prenotazioni/adapters/booker.py:336
+#: ../adapters/booker.py:386
 msgid "This gate has some booking schedule in this time period."
 msgstr "Lo sportello selezionato ha già delle prenotazioni nel periodo indicato."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:112
+#: ../content/prenotazioni_folder.py:111
 msgid "Thursday"
 msgstr "Giovedì"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:110
+#: ../content/prenotazioni_folder.py:109
 msgid "Tuesday"
 msgstr "Martedì"
 
-#: redturtle/prenotazioni/configure.zcml:40
+#: ../configure.zcml:40
 msgid "Uninstalls the redturtle.prenotazioni add-on."
 msgstr "Disinstall redturtle.prenotazioni"
 
-#: redturtle/prenotazioni/staging/configure.zcml:25
-msgid "Uninstalls the redturtle.prenotazioni.staging add-on (demo site purpose only)."
-msgstr "Disinstalla redturtle.prenotazioni.staging."
+#: ../demo/configure.zcml:25
+msgid "Uninstalls the redturtle.prenotazioni.demo add-on (demo site purpose only)."
+msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:113
+#: ../restapi/services/booking/add.py:158
 msgid "Unknown booking type '${booking_type}'."
 msgstr "Tipologia di prenotazione sconosciuta '${booking_type}'."
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "View"
 msgstr "Vista"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:111
+#: ../content/prenotazioni_folder.py:110
 msgid "Wednesday"
 msgstr "Mercoledì"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:213
+#: ../content/prenotazioni_folder.py:225
 msgid "Week table"
 msgstr "Schedulazione Settimanale"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:192
+#: ../content/prenotazioni_folder.py:204
 msgid "Yes"
 msgstr "Si"
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:70
+#: ../restapi/services/booking/add.py:115
 msgid "You are not allowed to force the gate."
 msgstr "Non hai i permessi necessari a forzare lo sportello."
 
-#: redturtle/prenotazioni/content/validators.py:92
+#: ../content/validators.py:70
 msgid "You must set both start and end"
 msgstr "Devi impostare sia un orario di inizio che di termine della pausa"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:400
-#: redturtle/prenotazioni/content/validators.py:203
+#: ../content/prenotazioni_folder.py:413
+#: ../content/validators.py:191
 msgid "You should set a start time for afternoon."
 msgstr "Devi impostare una data di inizio per il pomeriggio."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:396
-#: redturtle/prenotazioni/content/validators.py:195
+#: ../content/prenotazioni_folder.py:409
+#: ../content/validators.py:183
 msgid "You should set a start time for morning."
 msgstr "Devi impostare una data di inizio per la mattina."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:398
-#: redturtle/prenotazioni/content/validators.py:199
+#: ../content/prenotazioni_folder.py:411
+#: ../content/validators.py:187
 msgid "You should set an end time for afternoon."
 msgstr "Devi impostare una data di fine per il pomeriggio."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:394
-#: redturtle/prenotazioni/content/validators.py:191
+#: ../content/prenotazioni_folder.py:407
+#: ../content/validators.py:179
 msgid "You should set an end time for morning."
 msgstr "Devi impostare una data di fine per la mattina."
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:124
+#: ../adapters/stringinterp.py:124
 msgid "[DEPRECATED] The booking print url with delete token."
 msgstr "[DEPRECATO] L'url della prenotazione con il token per la cancellazione."
 
 #. Default: "Leave empty, and this Booking Folder will never expire"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:182
+#: ../content/prenotazioni_folder.py:194
 msgid "aData_help"
 msgstr "Lascia vuoto, e questa Cartella Prenotazioni non avrà scadenza"
 
 #. Default: "Book"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:199
-#: redturtle/prenotazioni/browser/vacations.py:207
+#: ../browser/prenotazione_add.py:198
+#: ../browser/vacations.py:206
 msgid "action_book"
 msgstr "Prenota"
 
 #. Default: "Cancel"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:252
-#: redturtle/prenotazioni/browser/prenotazione_move.py:147
-#: redturtle/prenotazioni/browser/vacations.py:232
+#: ../browser/prenotazione_add.py:251
+#: ../browser/prenotazione_move.py:145
+#: ../browser/vacations.py:231
 msgid "action_cancel"
 msgstr "Cancella"
 
 #. Default: "Move"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:122
+#: ../browser/prenotazione_move.py:120
 msgid "action_move"
 msgstr "Sposta"
 
 #. Default: "Search"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:250
+#: ../browser/prenotazioni_search.py:263
 msgid "action_search"
 msgstr "Cerca"
 
 #. Default: "End time in the afternoon"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:96
+#: ../content/prenotazioni_folder.py:95
 msgid "afternoon_end_label"
 msgstr "Chiusura pomeriggio"
 
 #. Default: "Start time in the afternoon"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:90
+#: ../content/prenotazioni_folder.py:89
 msgid "afternoon_start_label"
 msgstr "Apertura pomeriggio"
 
 #. Default: "All"
-#: redturtle/prenotazioni/vocabularies/voc_booking_type_gates.py:16
+#: ../vocabularies/voc_booking_type_gates.py:16
 msgid "all"
 msgstr "Tutti"
 
 #. Default: "Automatically confirm."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:358
+#: ../content/prenotazioni_folder.py:371
 msgid "auto_confirm"
 msgstr "Conferma automatica delle prenotazioni"
 
 #. Default: "All bookings will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:359
+#: ../content/prenotazioni_folder.py:372
 msgid "auto_confirm_help"
 msgstr "Tutte le prenotazioni verranno accettate automaticamente"
 
 #. Default: "Automatically confirmfor managers."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
+#: ../content/prenotazioni_folder.py:380
 msgid "auto_confirm_manager"
 msgstr "Conferma automatica delle prenotazioni dei Gestori"
 
 #. Default: "All bookings created by Managers will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:368
+#: ../content/prenotazioni_folder.py:381
 msgid "auto_confirm_manager_help"
 msgstr "Tutte le prenotazioni create dai Gestori verranno accettate automaticamente."
 
 #. Default: "End date should be greater than start."
-#: redturtle/prenotazioni/restapi/services/available_slots/get.py:44
+#: ../restapi/services/available_slots/get.py:48
 msgid "available_slots_wrong_dates"
 msgstr "La data di fine prenotazione deve essere maggiore della data di inizio."
 
 #. Default: "Please select a booking slot."
-#: redturtle/prenotazioni/browser/templates/week.pt:40
+#: ../browser/templates/week.pt:40
 msgid "book_it"
 msgstr "Per favore seleziona uno slot per la prenotazione"
 
 #. Default: "Bookable time"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:454
+#: ../browser/templates/prenotazione_macros.pt:454
 msgid "bookable_time"
 msgstr "Tempo prenotabile "
 
 #. Default: "${day}, ore ${booking_time}, prenotato da ${booked_by}, prenotazione: ${booking_type} durata: ${duration} minuti"
-#: redturtle/prenotazioni/browser/week.py:276
+#: ../browser/week.py:276
 msgid "booked_prenotation_message"
 msgstr "${day}, ore ${booking_time}, prenotato da ${booked_by}, prenotazione: ${booking_type} durata: ${duration} minuti"
 
 #. Default: "Booking confirmed"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:456
+#: ../browser/templates/prenotazione_macros.pt:456
 msgid "booking_confirmed"
 msgstr "Prenotazione confermata"
 
 #. Default: "Booking created"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:231
-#: redturtle/prenotazioni/browser/vacations.py:204
+#: ../browser/prenotazione_add.py:230
+#: ../browser/vacations.py:203
 msgid "booking_created"
 msgstr "Prenotazione creata"
 
 #. Default: "Your booking has been deleted."
-#: redturtle/prenotazioni/browser/delete_reservation.py:114
+#: ../browser/delete_reservation.py:114
 msgid "booking_deleted_success"
 msgstr "La tua prenotazione è stata cancellata."
 
 #. Default: "Booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:500
+#: ../content/prenotazioni_folder.py:513
 msgid "booking_fields_label"
 msgstr "Campi Prenotazioni"
 
-#: redturtle/prenotazioni/browser/prenotazione_move.py:137
+#: ../browser/prenotazione_move.py:135
 msgid "booking_moved"
 msgstr "Prenotazione spostata correttamente"
 
 #. Default: "Booking pending"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:458
+#: ../browser/templates/prenotazione_macros.pt:458
 msgid "booking_pending"
 msgstr "Prenotazione da confermare"
 
 #. Default: "Booking refused"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:460
+#: ../browser/templates/prenotazione_macros.pt:460
 msgid "booking_refused"
 msgstr "Prenotazione rifiutata "
 
 #. Default: "Duration value"
-#: redturtle/prenotazioni/content/prenotazione_type.py:15
+#: ../content/prenotazione_type.py:15
 msgid "booking_type_duration_label"
 msgstr "Durata"
 
 #. Default: "Name"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:427
+#: ../browser/templates/prenotazione_macros.pt:427
 msgid "booking_type_name"
 msgstr "Nome"
 
 #. Default: "List of requirements to recieve the service"
-#: redturtle/prenotazioni/content/prenotazione_type.py:23
+#: ../content/prenotazione_type.py:23
 msgid "booking_type_requirements_help"
 msgstr "Elencare le informazioni utili per il giorno della prenotazione, come ad esempio i documenti da presentare."
 
 #. Default: "Requirements"
-#: redturtle/prenotazioni/content/prenotazione_type.py:22
+#: ../content/prenotazione_type.py:22
 msgid "booking_type_requirements_labled"
 msgstr "Cosa serve"
 
 #. Default: "Value"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:428
+#: ../browser/templates/prenotazione_macros.pt:428
 msgid "booking_type_value"
 msgstr "Durata"
 
 #. Default: "You may want to select another time slot to book one of these."
-#: redturtle/prenotazioni/browser/templates/booking_type_radio_widget.pt:77
+#: ../browser/templates/booking_type_radio_widget.pt:77
 msgid "booking_type_widget_suggest_reselect"
 msgstr "Prova a selezionare un'orario differente per prenotarle."
 
 #. Default: "The following tipologies will not fit the time you selected:"
-#: redturtle/prenotazioni/browser/templates/booking_type_radio_widget.pt:65
+#: ../browser/templates/booking_type_radio_widget.pt:65
 msgid "booking_type_widget_warn_unavailable"
 msgstr "Le seguenti tipologie non sono selezionabili nell'orario selezionato:"
 
 #. Default: "Set message text for all available notification events."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:257
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:257
 msgid "bookings_appio_templates_help"
 msgstr "Imposta i testi dei messaggi per i vari tipi di notifiche disponibili."
 
 #. Default: "AppIO Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:253
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:253
 msgid "bookings_appio_templates_label"
 msgstr "Notifiche AppIO"
 
 #. Default: "Set message text for all available notification events."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:266
+#: ../behaviors/booking_folder/notifications/email/__init__.py:266
 msgid "bookings_email_templates_help"
 msgstr "Imposta i testi dei messaggi per i vari tipi di notifiche disponibili."
 
 #. Default: "Email Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:262
+#: ../behaviors/booking_folder/notifications/email/__init__.py:262
 msgid "bookings_email_templates_label"
 msgstr "Notifiche E-mail"
 
 #. Default: "Booking limit({limit}) for the {booking_type} type is exceed for the current user"
-#: redturtle/prenotazioni/exceptions/booker.py:15
+#: ../exceptions/booker.py:15
 msgid "bookings_limit_exceeded_exception"
 msgstr "Attenzione: hai superato il massimo di {limit} prenotazioni per la tipologia {booking_type}. Potrai richiedere nuove prenotazioni ad appuntamento avvenuto"
 
 #. Default: "Bookings not in agenda"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:111
+#: ../browser/templates/prenotazione_macros.pt:111
 msgid "bookings_not_in_agenda"
 msgstr "Prenotazioni non in agenda"
 
 #. Default: "Set message text for all available notification events. Remember that SMS has a 160 characters limit. Depending on your gateway service, it can split messages, if you exceed that limit."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:144
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:144
 msgid "bookings_sms_templates_help"
 msgstr "Imposta i testi dei messaggi per i vari tipi di notifiche disponibili. Gli sms hanno un limite di 160 caratteri. A seconda del gateway per l'invio utilizzato, i messaggi più lunghi potrebbero venire spezzati in più parti."
 
 #. Default: "SMS Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:140
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:140
 msgid "bookings_sms_templates_label"
 msgstr "Notifiche SMS"
 
 #. Default: "Busy"
-#: redturtle/prenotazioni/browser/prenotazioni_context_state.py:45
+#: ../browser/prenotazioni_context_state.py:44
 msgid "busy"
 msgstr "Occupato"
 
+#. Default: "Your booking has been canceled."
+#: ../browser/prenotazione_print.py:35
+msgid "confirm_booking_canceled_message"
+msgstr "La tua prenotazione è stata annullata."
+
 #. Default: "Your booking has been confirmed."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:28
+#: ../browser/prenotazione_print.py:27
 msgid "confirm_booking_confirmed_message"
 msgstr "La tua prenotazione è confermata."
 
 #. Default: "Your booking has been refused."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:32
+#: ../browser/prenotazione_print.py:31
 msgid "confirm_booking_refused_message"
 msgstr "La tua prenotazione è stata rifiutata."
 
 #. Default: "Your booking has to be confirmed by the administrators."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:24
+#: ../browser/prenotazione_print.py:23
 msgid "confirm_booking_waiting_message"
 msgstr "La tua prenotazione deve essere confermata dagli amministratori."
 
 #. Default: "Show here contacts information that will be used by authomatic mail system"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:49
+#: ../behaviors/booking_folder/contacts.py:49
 msgid "contacts_help"
 msgstr "Indicare tutte le informazioni di contatto che saranno usate dal sistema  di mailing. Queste informazioni saranno usate tramite sostituzione di un testo di markup nelle \"Regole di contenuto\" pertanto qui ci sarà da inserire dei testi che si possano integrare correttamente con i testi delle regole."
 
 #. Default: "Contacts"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:48
+#: ../behaviors/booking_folder/contacts.py:48
 msgid "contacts_label"
 msgstr "Contatti"
 
 #. Default: "This day is not valid."
-#: redturtle/prenotazioni/browser/vacations.py:224
+#: ../browser/vacations.py:223
 msgid "day_error"
 msgstr "Questo day non è valido"
 
 #. Default: "Day of week"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:70
+#: ../content/prenotazioni_folder.py:69
 msgid "day_label"
 msgstr "Giorno"
 
 #. Default: "You can't delete your reservation; it's too late."
-#: redturtle/prenotazioni/browser/delete_reservation.py:138
+#: ../browser/delete_reservation.py:138
 msgid "delete_expired_booking"
 msgstr "Non puoi cancellare questa prenotazione; è troppo tardi."
 
 #. Default: "Delete reservation request for: ${name}"
-#: redturtle/prenotazioni/browser/delete_reservation.py:61
+#: ../browser/delete_reservation.py:61
 msgid "delete_reservation_request"
 msgstr "Cancella la richiesta di prenotazione per: ${name}"
 
 #. Default: "Unique booking code"
-#: redturtle/prenotazioni/content/prenotazione.py:181
+#: ../content/prenotazione.py:181
 msgid "description_booking_code"
 msgstr "Codice univoco della prenotazione"
 
 #. Default: "If you work for a company, please specify its name."
-#: redturtle/prenotazioni/content/prenotazione.py:161
+#: ../content/prenotazione.py:161
 msgid "description_company"
 msgstr "Se lavori per un'azienda, compila questo campo."
 
 #. Default: "The gate that will be unavailable"
-#: redturtle/prenotazioni/browser/vacations.py:68
+#: ../browser/vacations.py:68
 msgid "description_gate"
 msgstr "La postazione che non sarà disponibile."
 
 #. Default: "This text will appear in the calendar cells"
-#: redturtle/prenotazioni/browser/vacations.py:61
+#: ../browser/vacations.py:61
 msgid "description_title"
 msgstr "Questo testo apparirà nelle celle del calendario."
 
 #. Default: "Foreseen booking time: ${booking_time}"
-#: redturtle/prenotazioni/browser/week.py:225
+#: ../browser/week.py:225
 msgid "foreseen_booking_time"
 msgstr "Data prevista per la prenotazione: ${day}, alle ore ${booking_time}."
 
 #. Default: "${booking_time}, Orario non disponibile"
-#: redturtle/prenotazioni/browser/week.py:244
+#: ../browser/week.py:244
 msgid "foreseen_busy_time"
 msgstr "${booking_time}, Orario non disponibile."
 
-msgid "from_label"
-msgstr "Dal"
-
 #. Default: "You should set a start range."
-#: redturtle/prenotazioni/content/validators.py:160
+#: ../content/validators.py:148
 msgid "from_month_error"
 msgstr "Devi impostare una data di inizio."
 
 #. Default: "Selected day is too big for that month for \"from\" field."
-#: redturtle/prenotazioni/content/validators.py:167
+#: ../content/validators.py:155
 msgid "from_month_too_days_error"
 msgstr "Il giorno selezionato non è corretto per il mese selezionato nel campo \"Al\"."
 
 #. Default: "Fullname"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:55
+#: ../browser/templates/prenotazione.pt:55
 msgid "fullname"
 msgstr "Nome completo"
 
 #. Default: "Limit booking in the future to an amount of days in the future starting from the current day. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:329
+#: ../content/prenotazioni_folder.py:342
 msgid "futureDays"
 msgstr "Limita la prenotazione ad un certo numero di giorni nel futuro partendo dal day corrente.Lascia 0 per non dare limiti."
 
 #. Default: "Put gates here (one per line)."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:351
+#: ../content/prenotazioni_folder.py:364
 msgid "gates_help"
 msgstr "Inserisci le postazioni preposte (uno per riga)."
 
 #. Default: "Gates"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:350
+#: ../content/prenotazioni_folder.py:363
 msgid "gates_label"
 msgstr "Postazioni preposte"
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:156
+#: ../browser/prenotazione_add.py:155
 msgid "help_prenotazione_add"
 msgstr ""
 
 #. Default: "User will not be able to add a booking unless those fields are filled. Remember that, whatever you selected in this list, users have to supply at least one of \"Email\", \"Mobile\", or \"Telephone\""
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:164
+#: ../content/prenotazioni_folder.py:176
 msgid "help_required_booking_fields"
 msgstr "Gli utenti non saranno in grado di creare una prenotazione senza compilare i seguenti campi. Gli utenti saranno comunque sempre obbligati ad inserire un'email o un recapito telefonico."
 
 #. Default: "States if it is not allowed to reserve a booking during the current day"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:203
+#: ../content/prenotazioni_folder.py:215
 msgid "help_same_day_booking_disallowed"
 msgstr "Se selezionato, impedisce agli utenti di prenotare per il giorno corrente."
 
 #. Default: "List of available reservation type for the current agenda"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:424
+#: ../browser/templates/prenotazione_macros.pt:424
 msgid "help_tipologies"
 msgstr "Lista dei tipi di prenotazione disponibili per l'agenda corrente"
 
 #. Default: "User will not be able to add a booking unless those fields are filled. Remember that, whatever you selected in this list, users have to supply at least one of \"Email\" or \"Telephone\""
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:146
+#: ../content/prenotazioni_folder.py:158
 msgid "help_visible_booking_fields"
 msgstr "Gli utenti vedranno solo i campi selezionati all'atto della creazione della prenotazione."
 
 #. Default: "Set holidays (one for line) in DD/MM/YYYY. you can write * for the year, if this event is yearly."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:304
+#: ../content/prenotazioni_folder.py:316
 msgid "holidays_help"
 msgstr "Imposta eventuali festività (una per riga) nel formato GG/MM/AAAA. Se la data si ripete ogni anno, puoi scrivere * al posto dell'anno."
 
 #. Default: "Holidays"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:303
+#: ../content/prenotazioni_folder.py:315
 msgid "holidays_label"
 msgstr "Festività"
 
 #. Default: "Booking for ${title}"
-#: redturtle/prenotazioni/adapters/ical.py:84
+#: ../adapters/ical.py:84
 msgid "ical_booking_label"
 msgstr "Prenotazione appuntamento per ${title}"
 
 #. Default: "Date should be in the format YYYY/mm/dd"
-#: redturtle/prenotazioni/browser/vacations.py:32
+#: ../browser/vacations.py:32
 msgid "invalid_date"
 msgstr "La data deve essere nel formato AAAA/MM/GG"
 
 #. Default: "Invalid email address"
-#: redturtle/prenotazioni/content/prenotazione.py:32
+#: ../content/prenotazione.py:32
 msgid "invalid_email_address"
 msgstr "Indirizzo email non valido"
 
 #. Default: "Invalid start or end date"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:40
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:26
+#: ../browser/prenotazioni_search.py:40
+#: ../browser/stats/booking_stats.py:26
 msgid "invalid_end:search_date"
 msgstr "Data di ricerca non valilda"
 
 #. Default: "Invalid fiscal code"
-#: redturtle/prenotazioni/content/prenotazione.py:40
+#: ../content/prenotazione.py:40
 msgid "invalid_fiscalcode"
 msgstr "Codice fiscale non valido"
 
 #. Default: "Invalid phone number"
-#: redturtle/prenotazioni/content/prenotazione.py:28
+#: ../content/prenotazione.py:28
 msgid "invalid_phone_number"
 msgstr "Numero di telefono non valido"
 
 #. Default: "Date should be in the format HH:MM"
-#: redturtle/prenotazioni/browser/vacations.py:36
+#: ../browser/vacations.py:36
 msgid "invalid_time"
 msgstr "L'ora deve essere nel formato HH:MM"
 
 #. Default: "This date is past"
-#: redturtle/prenotazioni/content/prenotazione.py:36
+#: ../content/prenotazione.py:36
 msgid "is_not_future_date"
 msgstr "La data è nel passato."
 
 #. Default: "Booking code"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:106
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:123
-#: redturtle/prenotazioni/browser/templates/prenotazione_print.pt:110
+#: ../browser/templates/delete_reservation.pt:106
+#: ../browser/templates/prenotazione.pt:123
+#: ../browser/templates/prenotazione_print.pt:110
 msgid "label_booking_code"
 msgstr "Codice prenotazione"
 
 #. Default: "Company"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:62
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:38
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:75
+#: ../browser/templates/delete_reservation.pt:62
+#: ../browser/templates/manager_notification_mail.pt:38
+#: ../browser/templates/prenotazione.pt:75
 msgid "label_booking_company"
 msgstr "Azienda"
 
 #. Default: "Booking date"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:80
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:50
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:87
+#: ../browser/templates/delete_reservation.pt:80
+#: ../browser/templates/manager_notification_mail.pt:50
+#: ../browser/templates/prenotazione.pt:87
 msgid "label_booking_date"
 msgstr "Data prenotazione"
 
 #. Default: "${from_date} at ${at}"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:92
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:54
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:98
+#: ../browser/templates/delete_reservation.pt:92
+#: ../browser/templates/manager_notification_mail.pt:54
+#: ../browser/templates/prenotazione.pt:98
 msgid "label_booking_date_range"
 msgstr "${from_date} alle ore ${at}"
 
 #. Default: "Subject"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:41
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:74
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:46
+#: ../browser/prenotazione_add.py:40
+#: ../browser/templates/delete_reservation.pt:74
+#: ../browser/templates/manager_notification_mail.pt:46
 msgid "label_booking_description"
 msgstr "Note"
 
 #. Default: "Email"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:50
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:30
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:63
+#: ../browser/templates/delete_reservation.pt:50
+#: ../browser/templates/manager_notification_mail.pt:30
+#: ../browser/templates/prenotazione.pt:63
 msgid "label_booking_email"
 msgstr "Email"
 
 #. Default: "Fiscal code"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:68
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:42
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:79
+#: ../browser/templates/delete_reservation.pt:68
+#: ../browser/templates/manager_notification_mail.pt:42
+#: ../browser/templates/prenotazione.pt:79
 msgid "label_booking_fiscalcode"
 msgstr "Codice fiscale"
 
 #. Default: "Phone number"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:56
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:34
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:71
+#: ../browser/templates/delete_reservation.pt:56
+#: ../browser/templates/manager_notification_mail.pt:34
+#: ../browser/templates/prenotazione.pt:71
 msgid "label_booking_phone"
 msgstr "Numero di telefono"
 
 #. Default: "Staff notes"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:113
-#: redturtle/prenotazioni/content/prenotazione.py:186
+#: ../browser/templates/prenotazione.pt:113
+#: ../content/prenotazione.py:186
 msgid "label_booking_staff_notes"
 msgstr "Note del personale"
 
 #. Default: "Booking time"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:31
-#: redturtle/prenotazioni/content/prenotazione.py:126
+#: ../browser/prenotazione_move.py:30
+#: ../content/prenotazione.py:126
 msgid "label_booking_time"
 msgstr "Data e ora"
 
 #. Default: "Fullname"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:38
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:22
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:52
+#: ../browser/prenotazione_add.py:37
+#: ../browser/templates/manager_notification_mail.pt:22
+#: ../browser/templates/prenotazioni_search.pt:52
 msgid "label_booking_title"
 msgstr "Nome completo"
 
 #. Default: "Booking type"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:44
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:26
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:59
+#: ../browser/templates/delete_reservation.pt:44
+#: ../browser/templates/manager_notification_mail.pt:26
+#: ../browser/templates/prenotazione.pt:59
 msgid "label_booking_type"
 msgstr "Tipologia prenotazione"
 
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:293
-#: redturtle/prenotazioni/vocabularies/requirable_booking_fields.py:24
+#: ../browser/prenotazioni_search.py:306
+#: ../vocabularies/requirable_booking_fields.py:24
 msgid "label_booking_{}"
 msgstr ""
 
 #. Default: "End date"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:68
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:52
+#: ../browser/prenotazioni_search.py:68
+#: ../browser/stats/booking_stats.py:52
 msgid "label_end"
 msgstr "Data fine"
 
 #. Default: "End time"
-#: redturtle/prenotazioni/browser/vacations.py:84
+#: ../browser/vacations.py:84
 msgid "label_end_time"
 msgstr "Ora fine"
 
 #. Default: "Gate"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:32
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:56
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:100
+#: ../browser/prenotazione_move.py:31
+#: ../browser/prenotazioni_search.py:56
+#: ../browser/templates/delete_reservation.pt:100
 msgid "label_gate"
 msgstr "Postazione"
 
 #. Default: "Go to the booking to see more details and manage it: ${url}"
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:65
+#: ../browser/templates/manager_notification_mail.pt:65
 msgid "label_new_booking_notify_link"
 msgstr "Vai alla <a href=\"${url}\">prenotazione</a> per gestirla e vedere maggiori dettagli"
 
 #. Default: "Required booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:163
+#: ../content/prenotazioni_folder.py:175
 msgid "label_required_booking_fields"
 msgstr "Campi obbligatori"
 
 #. Default: "Disallow same day booking"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:199
+#: ../content/prenotazioni_folder.py:211
 msgid "label_same_day_booking_disallowed"
 msgstr "Disabilita la prenotazione per lo stesso giorno"
 
 #. Default: "Selected date: ${date} — Time: ${slot}"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:141
+#: ../browser/prenotazione_add.py:140
 msgid "label_selected_date"
 msgstr "Data selezionata: ${date} — Alle ore: ${slot}"
 
 #. Default: "Start date "
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:62
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:45
-#: redturtle/prenotazioni/browser/vacations.py:73
+#: ../browser/prenotazioni_search.py:62
+#: ../browser/stats/booking_stats.py:45
+#: ../browser/vacations.py:73
 msgid "label_start"
 msgstr "Data inizio"
 
 #. Default: "Start time"
-#: redturtle/prenotazioni/browser/vacations.py:78
+#: ../browser/vacations.py:78
 msgid "label_start_time"
 msgstr "Ora inizio"
 
 #. Default: "Text to search"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:48
+#: ../browser/prenotazioni_search.py:48
 msgid "label_text"
 msgstr "Testo da ricercare"
 
 #. Default: "Reservation types"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:423
+#: ../browser/templates/prenotazione_macros.pt:423
 msgid "label_tipologies"
 msgstr "Tipi di prenotazione"
 
 #. Default: "Title"
-#: redturtle/prenotazioni/browser/vacations.py:60
+#: ../browser/vacations.py:60
 msgid "label_title"
 msgstr "Etichetta"
 
 #. Default: "User"
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:43
+#: ../browser/stats/booking_stats.py:43
 msgid "label_user"
 msgstr "Utente"
 
 #. Default: "Visible booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:145
+#: ../content/prenotazioni_folder.py:157
 msgid "label_visible_booking_fields"
 msgstr "Campi da visualizzare"
 
 #. Default: "Legend"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:447
+#: ../browser/templates/prenotazione_macros.pt:447
 msgid "legend"
 msgstr "Legenda"
 
 #. Default: "Short description of available action for the booking board"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:448
+#: ../browser/templates/prenotazione_macros.pt:448
 msgid "legend_description"
 msgstr "Breve descrizione delle azioni disponibili per l'agenda"
 
 #. Default: "The minimum value of a single slot is 5 minutes. You cannot book a reservation when the needed time exceeds the available time."
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:469
+#: ../browser/templates/prenotazione_macros.pt:469
 msgid "legend_note"
 msgstr "L'unità di tempo minima è 5 minuti. La tua prenotazione non può eccedere il tempo disponibile."
 
 #. Default: "The number of simultaneous bookings allowed for the same user."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:449
+#: ../content/prenotazioni_folder.py:462
 msgid "max_bookings_allowed_description"
 msgstr "Numero massimo delle prenotazioni contemporanee per una stessa tipologia, per lo stesso utente. Impostare '0' o lasciare vuoto per non porre limitazioni. Per attivare questo controllo è necessario richiedere obbligatoriamente all'utente il campo 'codice fiscale'"
 
 #. Default: "Maximum bookings number allowed"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:445
+#: ../content/prenotazioni_folder.py:458
 msgid "max_bookings_allowed_label"
 msgstr "Numero massimo delle prenotazioni"
 
 #. Default: "Unable to find a booking with the givend id: ${uid}."
-#: redturtle/prenotazioni/browser/delete_reservation.py:44
+#: ../browser/delete_reservation.py:44
 msgid "missing_booking"
 msgstr "Impossibile trovare la prenotazione con id: ${uid}."
 
 #. Default: "You need to provide a reservation id."
-#: redturtle/prenotazioni/browser/delete_reservation.py:38
+#: ../browser/delete_reservation.py:38
 msgid "missing_uid"
 msgstr "Devi fornite un'id prenotazione."
 
-msgid "month_label"
-msgstr "Mese"
-
 #. Default: "End time in the morning"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:84
+#: ../content/prenotazioni_folder.py:83
 msgid "morning_end_label"
 msgstr "Chiusura mattina"
 
 #. Default: "Start time in the morning"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:79
+#: ../content/prenotazioni_folder.py:78
 msgid "morning_start_label"
 msgstr "Apertura mattina"
 
 #. Default: "Go back to the calendar"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:260
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:192
-#: redturtle/prenotazioni/browser/templates/prenotazione_add.pt:127
+#: ../browser/prenotazioni_search.py:273
+#: ../browser/templates/prenotazione.pt:192
+#: ../browser/templates/prenotazione_add.pt:127
 msgid "move_back_message"
 msgstr "Ritorna al calendario"
 
 #. Default: "Move booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:163
+#: ../browser/templates/prenotazione.pt:163
 msgid "move_booking"
 msgstr "Sposta la prenotazione"
 
 #. Default: "Please move this booking into a new available slot or"
-#: redturtle/prenotazioni/browser/templates/prenotazione_move.pt:39
+#: ../browser/templates/prenotazione_move.pt:39
 msgid "move_message"
 msgstr "Spostare l'appuntamento selezionato in un area libera oppure"
 
 #. Default: "next week"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:39
+#: ../browser/templates/prenotazione_macros.pt:39
 msgid "next-week"
 msgstr "Settimana successiva"
 
 #. Default: "Booking is not allowed before the amount of days specified. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:341
+#: ../content/prenotazioni_folder.py:354
 msgid "notBeforeDays"
 msgstr "La prenotazione non e' permessa prima del numero di giorni specificata. Impostare il valore 0 per non imporre limitazioni."
 
 #. Default: "Enable AppIO notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:123
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:123
 msgid "notifications_appio_enabled_help"
 msgstr "Abilita le notifiche via App IO. I campi del messaggio accettano il formato Markdown"
 
 #. Default: "AppIO notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:122
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:122
 msgid "notifications_appio_enabled_label"
 msgstr "Notifiche AppIO"
 
 #. Default: "Enable Email notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:123
+#: ../behaviors/booking_folder/notifications/email/__init__.py:123
 msgid "notifications_email_enabled_help"
 msgstr "Abilita le notifiche via email"
 
 #. Default: "Email notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:122
+#: ../behaviors/booking_folder/notifications/email/__init__.py:122
 msgid "notifications_email_enabled_label"
 msgstr "Notifiche Email"
 
 #. Default: "Notifications"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:508
+#: ../content/prenotazioni_folder.py:521
 msgid "notifications_label"
 msgstr "Gestione delle Notifiche"
 
 #. Default: "Enable SMS notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:70
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:70
 msgid "notifications_sms_enabled_help"
 msgstr "Abilita le notifiche via SMS. Per poter ricevere un SMS, il campo 'Numero di telefono' della Prenotazione deve essere compilato."
 
 #. Default: "SMS notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:69
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:69
 msgid "notifications_sms_enabled_label"
 msgstr "Notifiche SMS"
 
 #. Default: "This is an automatic reminder about your booking on ${date} for ${booking_type}.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:111
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:111
 msgid "notify_as_reminder_appio_message_default_value"
 msgstr "Promemoria automatico per la prenotazione per ${booking_type} il ${booking_date} alle ${booking_time}. <br/><br/>Dal tuo [promemoria](${booking_print_url}) puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "[${prenotazioni_folder_title}] Booking reminder on ${booking_date}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:101
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:101
 msgid "notify_as_reminder_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Promemoria prenotazione del ${booking_date}"
 
 #. Default: "The message subject when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:231
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:231
 msgid "notify_as_reminder_appio_subject_help"
 msgstr "L'oggetto del messaggio inviato come promemoria."
 
 #. Default: "[Reminder] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:239
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:248
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:126
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:239
+#: ../behaviors/booking_folder/notifications/email/__init__.py:248
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:126
 msgid "notify_as_reminder_message"
 msgstr "[Promemoria] messaggio"
 
 #. Default: "This is an automatic reminder about your booking on ${date} for ${booking_type}.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:111
+#: ../behaviors/booking_folder/notifications/email/__init__.py:111
 msgid "notify_as_reminder_message_default_value"
 msgstr "Promemoria automatico per la prenotazione per ${booking_type} il ${booking_date} alle ${booking_time}. <br/><br/>Dal tuo <a href=${booking_print_url}>promemoria</a> puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "The message text when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:243
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:252
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:130
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:243
+#: ../behaviors/booking_folder/notifications/email/__init__.py:252
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:130
 msgid "notify_as_reminder_message_help"
 msgstr "Il testo del messaggio inviato come promemoria."
 
 #. Default: "[${prenotazioni_folder_title}]: This is an automatic reminder about your booking on ${date} for ${booking_type}.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:58
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:58
 msgid "notify_as_reminder_sms_message_default_value"
 msgstr ""
 "[${prenotazioni_folder_title}]: Promemoria prenotazione per ${booking_type} il ${booking_date} alle ${booking_time}.\n"
 "Per dettagli: ${booking_print_url}."
 
 #. Default: "[Reminder] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:227
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:236
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:227
+#: ../behaviors/booking_folder/notifications/email/__init__.py:236
 msgid "notify_as_reminder_subject"
 msgstr "[Promemoria] oggetto"
 
 #. Default: "[${prenotazioni_folder_title}] Booking reminder on ${booking_date}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:101
+#: ../behaviors/booking_folder/notifications/email/__init__.py:101
 msgid "notify_as_reminder_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Promemoria prenotazione del ${booking_date}"
 
 #. Default: "The message subject when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:240
+#: ../behaviors/booking_folder/notifications/email/__init__.py:240
 msgid "notify_as_reminder_subject_help"
 msgstr "L'oggetto del messaggio inviato come promemoria."
 
 #. Default: "Notify when confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:418
+#: ../content/prenotazioni_folder.py:431
 msgid "notify_on_confirm"
 msgstr "Notifica alla conferma"
 
 #. Default: "The booking ${booking_type} for ${title} has been confirmed.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:48
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:48
 msgid "notify_on_confirm_appio_message_default_value"
 msgstr ""
 "La prenotazione ${booking_type} per ${title} è stata confermata.  \n"
 "Dal tuo [promemoria](${booking_print_url}) puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "[${prenotazioni_folder_title}] Booking of ${booking_date} at ${booking_time} was accepted"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:38
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:38
 msgid "notify_on_confirm_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione del ${booking_date} alle ${booking_time} accettata"
 
 #. Default: "Notify via mail the user when his booking has been confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:419
+#: ../content/prenotazioni_folder.py:432
 msgid "notify_on_confirm_help"
 msgstr "Notifica l'utente quando la prenotazione viene confermata."
 
 #. Default: "[Confirmed] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:167
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:176
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:90
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:167
+#: ../behaviors/booking_folder/notifications/email/__init__.py:176
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:90
 msgid "notify_on_confirm_message"
 msgstr "[Conferma] messaggio"
 
 #. Default: "The booking ${booking_type} for ${title} has been confirmed.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:48
+#: ../behaviors/booking_folder/notifications/email/__init__.py:48
 msgid "notify_on_confirm_message_default_value"
 msgstr "La prenotazione ${booking_type} per ${title} è stata confermata.<br/><br/>Dal tuo <a href=${booking_print_url}>promemoria</a> puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "The message text when a booking has been confirmed."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:171
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:180
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:94
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:171
+#: ../behaviors/booking_folder/notifications/email/__init__.py:180
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:94
 msgid "notify_on_confirm_message_help"
 msgstr "Il testo del messaggio quando una prenotazione è stata confermata."
 
 #. Default: "[${prenotazioni_folder_title}]: Booking of ${booking_date} at ${booking_time} has been accepted.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:28
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:28
 msgid "notify_on_confirm_sms_message_default_value"
 msgstr ""
 "[${prenotazioni_folder_title}]: La prenotazione ${booking_type} per ${title} è stata confermata.\n"
 "Per dettagli: ${booking_print_url}."
 
 #. Default: "[Confirm] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:155
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:164
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:155
+#: ../behaviors/booking_folder/notifications/email/__init__.py:164
 msgid "notify_on_confirm_subject"
 msgstr "[Conferma] oggetto"
 
 #. Default: "[${prenotazioni_folder_title}] Booking of ${booking_date} at ${booking_time} was accepted"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:38
+#: ../behaviors/booking_folder/notifications/email/__init__.py:38
 msgid "notify_on_confirm_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione del ${booking_date} alle ${booking_time} accettata"
 
 #. Default: "The message subject when a booking has been confirmed."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:159
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:168
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:159
+#: ../behaviors/booking_folder/notifications/email/__init__.py:168
 msgid "notify_on_confirm_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata confermata."
 
 #. Default: "Notify when moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:427
+#: ../content/prenotazioni_folder.py:440
 msgid "notify_on_move"
 msgstr "Notifica allo spostamento"
 
 #. Default: "The booking scheduling for ${booking_type} was modified.<br/><br/>The new one is on ${booking_date} at ${booking_time}.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:69
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:69
 msgid "notify_on_move_appio_message_default_value"
 msgstr ""
 "L'orario della sua prenotazione ${booking_type} è stato modificato.  \n"
@@ -1315,365 +1299,370 @@ msgstr ""
 "Dal tuo [promemoria](${booking_print_url}) puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "[${prenotazioni_folder_title}] Booking date modified for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:59
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:59
 msgid "notify_on_move_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Data di prenotazione modificata per ${title}"
 
 #. Default: "Notify via mail the user when his booking has been moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:428
+#: ../content/prenotazioni_folder.py:441
 msgid "notify_on_move_help"
 msgstr "Notifica l'utente quando la prenotazione viene spostata di giorno/orario."
 
 #. Default: "[Move] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:191
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:200
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:102
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:191
+#: ../behaviors/booking_folder/notifications/email/__init__.py:200
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:102
 msgid "notify_on_move_message"
 msgstr "[Spostamento] messaggio"
 
 #. Default: "The booking scheduling for ${booking_type} was modified.<br/><br/>The new one is on ${booking_date} at ${booking_time}.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:69
+#: ../behaviors/booking_folder/notifications/email/__init__.py:69
 msgid "notify_on_move_message_default_value"
 msgstr "L'orario della sua prenotazione ${booking_type} è stato modificato.<br/><br/>La nuova data è ${booking_date} alle ore ${booking_time}.<br/><br/>Dal tuo <a href=${booking_print_url}>promemoria</a> puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "The message text when a booking has been moved."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:195
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:204
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:106
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:195
+#: ../behaviors/booking_folder/notifications/email/__init__.py:204
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:106
 msgid "notify_on_move_message_help"
 msgstr "Il testo del messaggio quando una prenotazione è stata spostata."
 
 #. Default: "[${prenotazioni_folder_title}]: The booking scheduling for ${booking_type} was modified.\nThe new one is on ${booking_date} at ${booking_time}.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:38
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:38
 msgid "notify_on_move_sms_message_default_value"
 msgstr ""
 "[${prenotazioni_folder_title}]: orario della prenotazione ${booking_type} modificato: ${booking_date} alle ${booking_time}.\n"
 "Per dettagli: ${booking_print_url}."
 
 #. Default: "[Move] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:179
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:188
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:179
+#: ../behaviors/booking_folder/notifications/email/__init__.py:188
 msgid "notify_on_move_subject"
 msgstr "[Spostamento] oggetto"
 
 #. Default: "[${prenotazioni_folder_title}] Booking date modified for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:59
+#: ../behaviors/booking_folder/notifications/email/__init__.py:59
 msgid "notify_on_move_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Data di prenotazione modificata per ${title} - ${booking_date}"
 
 #. Default: "The message subject when a booking has been moved."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:183
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:192
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:183
+#: ../behaviors/booking_folder/notifications/email/__init__.py:192
 msgid "notify_on_move_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata spostata."
 
 #. Default: "Notify when rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
+#: ../content/prenotazioni_folder.py:449
 msgid "notify_on_refuse"
 msgstr "Notifica alla cancellazione"
 
 #. Default: "The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:91
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:91
 msgid "notify_on_refuse_appio_message_default_value"
 msgstr "La prenotazione ${booking_type} del ${booking_date} delle ore ${booking_time} è stata rifiutata. Motivo del rifiuto: ${booking_refuse_message}"
 
 #. Default: "[${prenotazioni_folder_title}] Booking refused for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:81
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:81
 msgid "notify_on_refuse_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione rifiutata per ${title}"
 
 #. Default: "Notify via mail the user when his booking has been rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:437
+#: ../content/prenotazioni_folder.py:450
 msgid "notify_on_refuse_help"
 msgstr "Notifica l'utente via mail se la prenotazione viene cancellata"
 
 #. Default: "[Refuse] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:215
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:224
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:114
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:215
+#: ../behaviors/booking_folder/notifications/email/__init__.py:224
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:114
 msgid "notify_on_refuse_message"
 msgstr "Testo notifica prenotazione rifiutata"
 
 #. Default: "The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:91
+#: ../behaviors/booking_folder/notifications/email/__init__.py:91
 msgid "notify_on_refuse_message_default_value"
 msgstr "La prenotazione ${booking_type} del ${booking_date} delle ore ${booking_time} è stata rifiutata. Motivo del rifiuto: ${booking_refuse_message}"
 
 #. Default: "The message text when a booking has been refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:219
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:228
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:118
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:219
+#: ../behaviors/booking_folder/notifications/email/__init__.py:228
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:118
 msgid "notify_on_refuse_message_help"
 msgstr "Il testo del messaggio quando una prenotazione è stata rifiutata."
 
 #. Default: "[${prenotazioni_folder_title}]: The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:48
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:48
 msgid "notify_on_refuse_sms_message_default_value"
 msgstr ""
 "[${prenotazioni_folder_title}]: La prenotazione ${booking_type} del ${booking_date} alle ${booking_time} è stata rifiutata.\n"
 "Motivo: ${booking_refuse_message}"
 
 #. Default: "[Refuse] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:203
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:212
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:203
+#: ../behaviors/booking_folder/notifications/email/__init__.py:212
 msgid "notify_on_refuse_subject"
 msgstr "[Rifiuto] oggetto"
 
 #. Default: "[${prenotazioni_folder_title}] Booking refused for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:81
+#: ../behaviors/booking_folder/notifications/email/__init__.py:81
 msgid "notify_on_refuse_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione rifiutata per ${title}"
 
 #. Default: "The message subject when a booking has been refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:207
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:216
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:207
+#: ../behaviors/booking_folder/notifications/email/__init__.py:216
 msgid "notify_on_refuse_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata rifiutata."
 
 #. Default: "Notify when created."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:409
+#: ../content/prenotazioni_folder.py:422
 msgid "notify_on_submit"
 msgstr "Notifica alla creazione"
 
 #. Default: "Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.<br/><br/>You can see details and print a reminder following this [${booking_print_url}](link)."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:28
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:28
 msgid "notify_on_submit_appio_message_default_value"
 msgstr ""
 "La prenotazione ${booking_type} per il ${booking_date} alle ${booking_time} è stata creata.  \n"
 "Dal tuo [${booking_print_url}](promemoria) puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "[${prenotazioni_folder_title}] Booking created"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:18
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:18
 msgid "notify_on_submit_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione creata"
 
 #. Default: "Notify via mail the user when his booking has been created. If auto-confirm flag is selected and confirm notify is selected, this one will be ignored."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:410
+#: ../content/prenotazioni_folder.py:423
 msgid "notify_on_submit_help"
 msgstr "Notifica l'utente quando la prenotazione viene creata. Se il flag di conferma automatica e di notifica alla conferma sono selezionati, questa opzione verrà ignorata."
 
 #. Default: "[Created] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:143
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:152
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:78
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:143
+#: ../behaviors/booking_folder/notifications/email/__init__.py:152
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:78
 msgid "notify_on_submit_message"
 msgstr "[Creazione] messaggio"
 
 #. Default: "Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:28
+#: ../behaviors/booking_folder/notifications/email/__init__.py:28
 msgid "notify_on_submit_message_default_value"
 msgstr "La prenotazione ${booking_type} per il ${booking_date} alle ${booking_time} è stata creata.<br/><br/>Dal tuo <a href=${booking_print_url}>promemoria</a> puoi controllare i dati, stampare ed eventualmente cancellare la prenotazione."
 
 #. Default: "The message text when a booking has been created."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:147
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:156
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:82
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:147
+#: ../behaviors/booking_folder/notifications/email/__init__.py:156
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:82
 msgid "notify_on_submit_message_help"
 msgstr "Il testo del messaggio quando una prenotazione è stata creata."
 
 #. Default: "[${prenotazioni_folder_title}]: Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:18
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:18
 msgid "notify_on_submit_sms_message_default_value"
 msgstr "[${prenotazioni_folder_title}]: La prenotazione ${booking_type} per il ${booking_date} alle ${booking_time} è stata creata. Per dettagli: ${booking_print_url}."
 
 #. Default: "[Created] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:131
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:140
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:131
+#: ../behaviors/booking_folder/notifications/email/__init__.py:140
 msgid "notify_on_submit_subject"
 msgstr "[Creazione] oggetto"
 
 #. Default: "[${prenotazioni_folder_title}] Booking created"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:18
+#: ../behaviors/booking_folder/notifications/email/__init__.py:18
 msgid "notify_on_submit_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione creata"
 
 #. Default: "The message subject when a booking has been created."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:135
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:144
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:135
+#: ../behaviors/booking_folder/notifications/email/__init__.py:144
 msgid "notify_on_submit_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata creata."
 
 #. Default: "Pause end"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:125
+#: ../content/prenotazioni_folder.py:124
 msgid "pause_end_label"
 msgstr "Termine pausa"
 
 #. Default: "Pause start"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:120
+#: ../content/prenotazioni_folder.py:119
 msgid "pause_start_label"
 msgstr "Inizio pausa"
 
 #. Default: "Please select a time slot"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:280
+#: ../browser/prenotazione_add.py:279
 msgid "please_pick_a_date"
 msgstr "Selezionare una data"
 
 #. Default: "${day}, ore ${booking_time}"
-#: redturtle/prenotazioni/browser/week.py:256
+#: ../browser/week.py:256
 msgid "prenotation_slot_message"
 msgstr "${day}, ore ${booking_time}"
 
 #. Default: "prenotazioni_search"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "prenotazioni_search"
 msgstr "Ricerca"
 
 #. Default: "previous week"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:14
+#: ../browser/templates/prenotazione_macros.pt:14
 msgid "previous-week"
 msgstr "Settimana precedente"
 
-#: redturtle/prenotazioni/configure.zcml:31
+#: ../configure.zcml:31
 msgid "redturtle.prenotazioni"
 msgstr "redturtle.prenotazioni"
 
-#: redturtle/prenotazioni/configure.zcml:48
+#: ../configure.zcml:48
 msgid "redturtle.prenotazioni (to_1500)"
 msgstr "redturtle.prenotazioni (to_1500)"
 
-#: redturtle/prenotazioni/configure.zcml:40
-#: redturtle/prenotazioni/staging/configure.zcml:25
+#: ../configure.zcml:56
+msgid "redturtle.prenotazioni (to_2005)"
+msgstr ""
+
+#: ../configure.zcml:40
+#: ../demo/configure.zcml:25
 msgid "redturtle.prenotazioni (uninstall)"
 msgstr "redturtle.prenotazioni (disinstalla)"
 
-#: redturtle/prenotazioni/configure.zcml:48
+#: ../configure.zcml:48
 msgid "redturtle.prenotazioni to 1500."
 msgstr "redturtle.prenotazioni to 1500."
 
-#: redturtle/prenotazioni/staging/configure.zcml:16
-msgid "redturtle.prenotazioni.staging"
+#: ../configure.zcml:56
+msgid "redturtle.prenotazioni to 2005."
+msgstr ""
+
+#: ../demo/configure.zcml:16
+msgid "redturtle.prenotazioni.demo"
 msgstr ""
 
 #. Default: "The booking state is \"refused\". If you change it, the booking time may conflict with another one."
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:30
+#: ../browser/templates/prenotazione.pt:30
 msgid "refused-review-state-warning"
 msgstr "Lo stato della prenotazione è \"rifiutato\". Se lo cambi, questa prenotazione potrebbe entrare in conflitto con un'altra."
 
 #. Default: "Reject booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:176
+#: ../browser/templates/prenotazione.pt:176
 msgid "reject_booking"
 msgstr "Rifiuta la prenotazione"
 
 #. Default: "Set how many days before of a booking date the user will be notified about it."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:461
+#: ../content/prenotazioni_folder.py:474
 msgid "reminder_notification_gap_description"
 msgstr "Indicare quanti giorni prima della data di prenotazione, inviare un promemoria agli utenti."
 
 #. Default: "Booking reminder days"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:457
+#: ../content/prenotazioni_folder.py:470
 msgid "reminder_notification_gap_label"
 msgstr "Promemoria prenotazione"
 
 #. Default: "Code"
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:58
+#: ../browser/templates/prenotazioni_search.pt:58
 msgid "reservation_code"
 msgstr "Codice prenotazione"
 
 #. Default: "Reservation date"
-#: redturtle/prenotazioni/browser/templates/prenotazione_move.pt:33
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:57
+#: ../browser/templates/prenotazione_move.pt:33
+#: ../browser/templates/prenotazioni_search.pt:57
 msgid "reservation_date"
 msgstr "Data prenotazione"
 
 #. Default: "Booking request for: ${name}"
-#: redturtle/prenotazioni/browser/prenotazione_print.py:44
+#: ../browser/prenotazione_print.py:47
 msgid "reservation_request"
 msgstr "Richiesta prenotazione per: ${name}"
 
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:30
+#: ../browser/templates/prenotazione_macros.pt:30
 msgid "resize"
 msgstr "Ridimensiona"
 
 #. Default: "items matching your search terms."
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:30
+#: ../browser/templates/prenotazioni_search.pt:30
 msgid "result_number"
 msgstr "elementi trovati"
 
 #. Default: "You need to provide a booking date to get the schema and available types."
-#: redturtle/prenotazioni/restapi/services/booking_schema/get.py:71
+#: ../restapi/services/booking_schema/get.py:71
 msgid "schema_missing_date"
 msgstr "Devi fornire una data di prenotazione, per avere lo schema e le tipologie disponibili."
 
 #. Default: "Search by gate"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:465
+#: ../browser/templates/prenotazione_macros.pt:465
 msgid "search-by-gate"
 msgstr "Ricerca per postazione"
 
 #. Default: "Search result"
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:12
+#: ../browser/templates/prenotazioni_search.pt:12
 msgid "search_result_message"
 msgstr "Risultato della ricerca"
 
 #. Default: "seleziona l'opzione desiderata dal gruppo di radio button seguente"
-#: redturtle/prenotazioni/browser/z3c_custom_widget.py:153
+#: ../browser/z3c_custom_widget.py:153
 msgid "select-option"
 msgstr "seleziona l'opzione desiderata dal gruppo di campi seguente"
 
 #. Default: "AppIO service code related to the current booking type"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:293
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:293
 msgid "service_code_help"
 msgstr "Matricola del servizio legato alla tipologia (serve per l'invio coretto delle notifiche)"
 
 #. Default: "AppIO service code."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:289
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:289
 msgid "service_code_label"
 msgstr "Matricola servizio App IO"
 
 #. Default: "This gate has some booking schedule in this time period."
-#: redturtle/prenotazioni/browser/vacations.py:217
+#: ../browser/vacations.py:216
 msgid "slot_conflict_error"
 msgstr "Questa postazione ha già appuntamenti schedulati in questo periodo."
 
 #. Default: "You cannot book any booking_type at this time"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:284
+#: ../browser/prenotazione_add.py:283
 msgid "time_slot_to_short"
 msgstr "Tempo insufficiente per qualsiasi tipologia di prenotazione"
 
-msgid "to_label"
-msgstr "Al"
-
 #. Default: "You should set an end range."
-#: redturtle/prenotazioni/content/validators.py:175
+#: ../content/validators.py:163
 msgid "to_month_error"
 msgstr "Devi impostare una data di inizio."
 
 #. Default: "Selected day is too big for that month for \"to\" field."
-#: redturtle/prenotazioni/content/validators.py:182
+#: ../content/validators.py:170
 msgid "to_month_too_days_error"
 msgstr "Il giorno selezionato non è compatibile col mese selezionato nel campo \"Al\"."
 
 #. Default: "You can't add a booking with type '${booking_type}'."
-#: redturtle/prenotazioni/restapi/services/booking/add.py:89
+#: ../restapi/services/booking/add.py:134
 msgid "unauthorized_add_vacation"
 msgstr "Impossibile creare una nuova prenotazione per la tipologia '${booking_type}'."
 
 #. Default: "Unbookable time"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:452
+#: ../browser/templates/prenotazione_macros.pt:452
 msgid "unbookable_time"
 msgstr "Tempo non prenotabile "
 
 #. Default: "vacation_booking"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "vacation_booking"
 msgstr "Blocco risorsa"
 
 #. Default: "View booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:143
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:463
+#: ../browser/templates/prenotazione.pt:143
+#: ../browser/templates/prenotazione_macros.pt:463
 msgid "view_booking"
 msgstr "Vedi la prenotazione"
 
 #. Default: "Insert here week schema for some custom date intervals."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:281
+#: ../content/prenotazioni_folder.py:293
 msgid "week_table_overrides_help"
 msgstr "Inserisci qui eventuali personalizzazioni nella schedulazione settimanale che andranno a vincere su quella standard per un determinato periodo di tempo."
 
 #. Default: "Week table overrides"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:280
+#: ../content/prenotazioni_folder.py:292
 msgid "week_table_overrides_label"
 msgstr "Personalizzazioni Schedulazione Settimanale"
 
 #. Default: "You tried to delete booking with a wrong action."
-#: redturtle/prenotazioni/browser/delete_reservation.py:97
+#: ../browser/delete_reservation.py:97
 msgid "wrong_authenticator"
 msgstr "Stai cercando di cancellare una prenotazione con un'azione sbagliata."

--- a/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-02-26 23:03+0000\n"
+"POT-Creation-Date: 2024-02-27 07:37+0000\n"
 "PO-Revision-Date: 2014-05-27 17:36+0200\n"
 "Last-Translator: Alessandro Pisa <alessandro.pisa@redturtle.it>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -606,7 +606,7 @@ msgid "booking_created"
 msgstr "Prenotazione creata"
 
 #. Default: "Your booking has been deleted."
-#: ../browser/delete_reservation.py:114
+#: ../browser/delete_reservation.py:115
 msgid "booking_deleted_success"
 msgstr "La tua prenotazione è stata cancellata."
 
@@ -750,12 +750,17 @@ msgid "day_label"
 msgstr "Giorno"
 
 #. Default: "You can't delete your reservation; it's too late."
-#: ../browser/delete_reservation.py:138
+#: ../browser/delete_reservation.py:139
 msgid "delete_expired_booking"
 msgstr "Non puoi cancellare questa prenotazione; è troppo tardi."
 
+#. Default: "You can't delete your reservation."
+#: ../browser/delete_reservation.py:149
+msgid "delete_refused_booking"
+msgstr "Non puoi cancellare questa prenotazione."
+
 #. Default: "Delete reservation request for: ${name}"
-#: ../browser/delete_reservation.py:61
+#: ../browser/delete_reservation.py:62
 msgid "delete_reservation_request"
 msgstr "Cancella la richiesta di prenotazione per: ${name}"
 
@@ -1082,12 +1087,12 @@ msgid "max_bookings_allowed_label"
 msgstr "Numero massimo delle prenotazioni"
 
 #. Default: "Unable to find a booking with the givend id: ${uid}."
-#: ../browser/delete_reservation.py:44
+#: ../browser/delete_reservation.py:45
 msgid "missing_booking"
 msgstr "Impossibile trovare la prenotazione con id: ${uid}."
 
 #. Default: "You need to provide a reservation id."
-#: ../browser/delete_reservation.py:38
+#: ../browser/delete_reservation.py:39
 msgid "missing_uid"
 msgstr "Devi fornite un'id prenotazione."
 
@@ -1663,6 +1668,6 @@ msgid "week_table_overrides_label"
 msgstr "Personalizzazioni Schedulazione Settimanale"
 
 #. Default: "You tried to delete booking with a wrong action."
-#: ../browser/delete_reservation.py:97
+#: ../browser/delete_reservation.py:98
 msgid "wrong_authenticator"
 msgstr "Stai cercando di cancellare una prenotazione con un'azione sbagliata."

--- a/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
+++ b/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-26 23:03+0000\n"
+"POT-Creation-Date: 2024-02-27 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -606,7 +606,7 @@ msgid "booking_created"
 msgstr ""
 
 #. Default: "Your booking has been deleted."
-#: ../browser/delete_reservation.py:114
+#: ../browser/delete_reservation.py:115
 msgid "booking_deleted_success"
 msgstr ""
 
@@ -750,12 +750,17 @@ msgid "day_label"
 msgstr ""
 
 #. Default: "You can't delete your reservation; it's too late."
-#: ../browser/delete_reservation.py:138
+#: ../browser/delete_reservation.py:139
 msgid "delete_expired_booking"
 msgstr ""
 
+#. Default: "You can't delete your reservation."
+#: ../browser/delete_reservation.py:149
+msgid "delete_refused_booking"
+msgstr ""
+
 #. Default: "Delete reservation request for: ${name}"
-#: ../browser/delete_reservation.py:61
+#: ../browser/delete_reservation.py:62
 msgid "delete_reservation_request"
 msgstr ""
 
@@ -1080,12 +1085,12 @@ msgid "max_bookings_allowed_label"
 msgstr ""
 
 #. Default: "Unable to find a booking with the givend id: ${uid}."
-#: ../browser/delete_reservation.py:44
+#: ../browser/delete_reservation.py:45
 msgid "missing_booking"
 msgstr ""
 
 #. Default: "You need to provide a reservation id."
-#: ../browser/delete_reservation.py:38
+#: ../browser/delete_reservation.py:39
 msgid "missing_uid"
 msgstr ""
 
@@ -1646,6 +1651,6 @@ msgid "week_table_overrides_label"
 msgstr ""
 
 #. Default: "You tried to delete booking with a wrong action."
-#: ../browser/delete_reservation.py:97
+#: ../browser/delete_reservation.py:98
 msgid "wrong_authenticator"
 msgstr ""

--- a/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
+++ b/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
@@ -1,10 +1,10 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#--- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+#SOME DESCRIPTIVE TITLE.
+#FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-01-08 14:16+0000\n"
+"POT-Creation-Date: 2024-02-26 23:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,1646 +17,1635 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: redturtle.prenotazioni\n"
 
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:63
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:46
-#: redturtle/prenotazioni/browser/vacations.py:74
+#: ../browser/prenotazioni_search.py:63
+#: ../browser/stats/booking_stats.py:46
+#: ../browser/vacations.py:74
 msgid " format (YYYY-MM-DD)"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniFolder.xml
+#: ../profiles/default/types/PrenotazioniFolder.xml
 msgid "A folder that will contain booking"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "A folder that will contain booking for this day"
 msgstr ""
 
-msgid "Add"
-msgstr ""
-
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:406
-#: redturtle/prenotazioni/content/validators.py:213
+#: ../content/prenotazioni_folder.py:419
+#: ../content/validators.py:201
 msgid "Afternoon start should not be greater than end."
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
+#: ../browser/templates/prenotazione.pt:29
 msgid "Attention"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:27
+#: ../adapters/stringinterp.py:27
 msgid "Booking"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniFolder.xml
+#: ../profiles/default/types/PrenotazioniFolder.xml
 msgid "Booking Folder"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioneType.xml
 msgid "Booking Type"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniWeek.xml
+#: ../profiles/default/types/PrenotazioniWeek.xml
 msgid "Booking Week Folder"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniYear.xml
+#: ../profiles/default/types/PrenotazioniYear.xml
 msgid "Booking Year Folder"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:17
 msgid "Booking folder notification appio"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/email/configure.zcml:17
 msgid "Booking folder notification email"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/sms/configure.zcml:17
 msgid "Booking folder notification sms"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:44
+#: ../browser/templates/prenotazione.pt:44
 msgid "Booking for"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:27
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:27
 msgid "Booking type notification appio"
 msgstr ""
 
 #. Default: "Change date/time"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "Change date/time"
 msgstr ""
 
 #. Default: "Complete address"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:43
+#: ../behaviors/booking_folder/contacts.py:43
 msgid "Complete address"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:36
+#: ../behaviors/booking_folder/contacts.py:36
 msgid "Contact PEC"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:30
+#: ../behaviors/booking_folder/contacts.py:30
 msgid "Contact fax"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:24
+#: ../behaviors/booking_folder/contacts.py:24
 msgid "Contact phone"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/configure.zcml:19
+#: ../behaviors/booking_folder/configure.zcml:18
 msgid "Contacts fields."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/configure.zcml:19
+#: ../behaviors/booking_folder/configure.zcml:18
 msgid "Contatti cartella prenotazioni"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:46
+#: ../browser/templates/prenotazioni_search.pt:46
 msgid "Content listing"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:181
+#: ../content/prenotazioni_folder.py:193
 msgid "Data fine validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:178
+#: ../content/prenotazioni_folder.py:190
 msgid "Data inizio validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:471
+#: ../content/prenotazioni_folder.py:484
 msgid "Date validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:340
+#: ../content/prenotazioni_folder.py:353
 msgid "Days booking is not allowed before"
 msgstr ""
 
-msgid "Delete"
-msgstr ""
-
 #. Default: "Descrizione Agenda"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:137
+#: ../content/prenotazioni_folder.py:149
 msgid "Descrizione Agenda"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "Edit"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:131
+#: ../behaviors/booking_folder/notifications/email/__init__.py:131
 msgid "Email from"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazione.py:175
+#: ../content/prenotazione.py:175
 msgid "Expiration date booking"
 msgstr ""
 
 #. Default: "Campo"
-#: redturtle/prenotazioni/browser/z3c_custom_widget.py:150
+#: ../browser/z3c_custom_widget.py:150
 msgid "Field"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:113
+#: ../content/prenotazioni_folder.py:112
 msgid "Friday"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:107
-#: redturtle/prenotazioni/content/prenotazione.py:170
+#: ../browser/templates/prenotazione.pt:107
+#: ../content/prenotazione.py:170
 msgid "Gate"
 msgstr ""
 
-msgid "Group"
-msgstr ""
-
 #. Default: "How to get here"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:19
+#: ../behaviors/booking_folder/contacts.py:19
 msgid "How to get here"
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:136
+#: ../content/validators.py:93
 msgid "In the same day there are overlapping intervals"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/Prenotazione.xml
 msgid "Informations about a single booking"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:138
+#: ../content/prenotazioni_folder.py:150
 msgid "Inserire il testo di presentazione dell'agenda corrente"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
+#: ../content/prenotazioni_folder.py:391
 msgid "Insert a list of email addresses that will be notified when new bookings get created."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:132
+#: ../behaviors/booking_folder/notifications/email/__init__.py:132
 msgid "Insert an email address used as \"from\" in email notifications. Leave empty to use the default from set in the site configuration."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:20
+#: ../behaviors/booking_folder/contacts.py:20
 msgid "Insert here indications on how to reach the office"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:44
+#: ../behaviors/booking_folder/contacts.py:44
 msgid "Insert here the complete office address"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:37
+#: ../behaviors/booking_folder/contacts.py:37
 msgid "Insert here the contact PEC"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:31
+#: ../behaviors/booking_folder/contacts.py:31
 msgid "Insert here the contact fax"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:25
+#: ../behaviors/booking_folder/contacts.py:25
 msgid "Insert here the contact phone"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:291
+#: ../content/prenotazioni_folder.py:303
 msgid "Insert pause table schema."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:214
+#: ../content/prenotazioni_folder.py:226
 msgid "Insert week table schema."
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:31
+#: ../configure.zcml:31
 msgid "Installs the redturtle.prenotazioni add-on."
 msgstr ""
 
-#: redturtle/prenotazioni/staging/configure.zcml:16
-msgid "Installs the redturtle.prenotazioni.staging add-on (demo site purpose only)."
+#: ../demo/configure.zcml:16
+msgid "Installs the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:328
+#: ../content/prenotazioni_folder.py:341
 msgid "Max days in the future"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:109
+#: ../content/prenotazioni_folder.py:108
 msgid "Monday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:403
-#: redturtle/prenotazioni/content/validators.py:208
+#: ../content/prenotazioni_folder.py:416
+#: ../content/validators.py:196
 msgid "Morning start should not be greater than end."
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:152
+#: ../browser/templates/prenotazione.pt:152
 msgid "Move booking"
 msgstr ""
 
-msgid "Move down"
-msgstr ""
-
-msgid "Move up"
-msgstr ""
-
-#: redturtle/prenotazioni/restapi/services/booking/vacation.py:27
+#: ../restapi/services/booking/vacation.py:27
 msgid "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:193
+#: ../content/prenotazioni_folder.py:205
 msgid "No"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:17
 msgid "Notification APPIo"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/configure.zcml:27
+#: ../behaviors/booking_folder/notifications/appio/configure.zcml:27
 msgid "Notification APPIo for PrenotazioneType c.t."
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/sms/configure.zcml:17
 msgid "Notification SMS"
 msgstr ""
 
-#: redturtle/prenotazioni/behaviors/booking_folder/email/configure.zcml:17
+#: ../behaviors/booking_folder/notifications/email/configure.zcml:17
 msgid "Notification email templates"
 msgstr ""
 
-#: redturtle/prenotazioni/content/pause.py:43
+#: ../content/pause.py:43
 msgid "Pause"
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:100
+#: ../content/validators.py:78
 msgid "Pause end should be greater than pause start"
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:121
+#: ../content/validators.py:122
 msgid "Pause should be included in morning slot or afternoon slot"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:290
+#: ../content/prenotazioni_folder.py:302
 msgid "Pause table"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:221
+#: ../browser/prenotazione_add.py:220
 msgid "Please provide a booking date"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/Prenotazione.xml
 msgid "Prenotazione"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "PrenotazioniDay"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniWeek.xml
+#: ../profiles/default/types/PrenotazioniWeek.xml
 msgid "PrenotazioniWeek"
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniYear.xml
+#: ../profiles/default/types/PrenotazioniYear.xml
 msgid "PrenotazioniYear"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione_print.pt:129
+#: ../browser/templates/prenotazione_print.pt:129
 msgid "Print"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:77
+#: ../restapi/services/booking/add.py:122
 msgid "Required input '${field}' is missing."
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:217
+#: ../browser/prenotazione_add.py:216
 msgid "Required input is missing."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:377
+#: ../content/prenotazioni_folder.py:390
 msgid "Responsible email"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:114
+#: ../content/prenotazioni_folder.py:113
 msgid "Saturday"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:16
+#: ../browser/templates/prenotazioni_search.pt:16
 msgid "Search for"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:108
+#: ../content/prenotazioni_folder.py:107
 msgid "Select a day"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:249
-#: redturtle/prenotazioni/restapi/services/booking/add.py:58
+#: ../adapters/booker.py:299
+#: ../restapi/services/booking/add.py:64
 msgid "Sorry, this slot is not available anymore."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:292
+#: ../adapters/booker.py:342
 msgid "Sorry, this slot is not available or does not fit your booking."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:143
+#: ../adapters/booker.py:151
 msgid "Sorry, you can not book this slot for now."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazione.py:171
+#: ../content/prenotazione.py:171
 msgid "Sportello a cui presentarsi"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:115
+#: ../content/prenotazioni_folder.py:114
 msgid "Sunday"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:37
+#: ../adapters/stringinterp.py:37
 msgid "The booked date."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:50
+#: ../adapters/stringinterp.py:50
 msgid "The booked end date."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:63
+#: ../adapters/stringinterp.py:63
 msgid "The booked time."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:96
+#: ../adapters/stringinterp.py:96
 msgid "The booking code."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:291
+#: ../adapters/stringinterp.py:291
 msgid "The booking folder title"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:211
+#: ../adapters/stringinterp.py:211
 msgid "The booking human readable date"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:177
+#: ../adapters/stringinterp.py:177
 msgid "The booking office contact fax."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:167
+#: ../adapters/stringinterp.py:167
 msgid "The booking office contact pec address."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:157
+#: ../adapters/stringinterp.py:157
 msgid "The booking office contact phone."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:250
+#: ../adapters/stringinterp.py:250
 msgid "The booking operator url"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:108
+#: ../adapters/stringinterp.py:108
 msgid "The booking print url."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:259
+#: ../adapters/stringinterp.py:259
 msgid "The booking refuse message"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:280
+#: ../adapters/stringinterp.py:280
 msgid "The booking requirements url"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:75
+#: ../adapters/stringinterp.py:75
 msgid "The booking time end."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:87
+#: ../adapters/stringinterp.py:87
 msgid "The booking type."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:238
+#: ../adapters/stringinterp.py:238
 msgid "The booking url with delete token"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:199
+#: ../adapters/stringinterp.py:199
 msgid "The complete address information of the office whereuser book a reservation"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:139
+#: ../adapters/stringinterp.py:139
 msgid "The email address of the user who made the reservation."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:28
+#: ../adapters/stringinterp.py:28
 msgid "The gate booked."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:187
+#: ../adapters/stringinterp.py:187
 msgid "The information to reach the office where user book a reservation"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:130
+#: ../adapters/stringinterp.py:130
 msgid "The phone number of the user who made the reservation."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:341
+#: ../adapters/booker.py:391
 msgid "This day is not valid."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:336
+#: ../adapters/booker.py:386
 msgid "This gate has some booking schedule in this time period."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:112
+#: ../content/prenotazioni_folder.py:111
 msgid "Thursday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:110
+#: ../content/prenotazioni_folder.py:109
 msgid "Tuesday"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:40
+#: ../configure.zcml:40
 msgid "Uninstalls the redturtle.prenotazioni add-on."
 msgstr ""
 
-#: redturtle/prenotazioni/staging/configure.zcml:25
-msgid "Uninstalls the redturtle.prenotazioni.staging add-on (demo site purpose only)."
+#: ../demo/configure.zcml:25
+msgid "Uninstalls the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:113
+#: ../restapi/services/booking/add.py:158
 msgid "Unknown booking type '${booking_type}'."
 msgstr ""
 
-#: redturtle/prenotazioni/profiles/default/types/Prenotazione.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioneType.xml
-#: redturtle/prenotazioni/profiles/default/types/PrenotazioniDay.xml
+#: ../profiles/default/types/Prenotazione.xml
+#: ../profiles/default/types/PrenotazioneType.xml
+#: ../profiles/default/types/PrenotazioniDay.xml
 msgid "View"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:111
+#: ../content/prenotazioni_folder.py:110
 msgid "Wednesday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:213
+#: ../content/prenotazioni_folder.py:225
 msgid "Week table"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:192
+#: ../content/prenotazioni_folder.py:204
 msgid "Yes"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:70
+#: ../restapi/services/booking/add.py:115
 msgid "You are not allowed to force the gate."
 msgstr ""
 
-#: redturtle/prenotazioni/content/validators.py:92
+#: ../content/validators.py:70
 msgid "You must set both start and end"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:400
-#: redturtle/prenotazioni/content/validators.py:203
+#: ../content/prenotazioni_folder.py:413
+#: ../content/validators.py:191
 msgid "You should set a start time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:396
-#: redturtle/prenotazioni/content/validators.py:195
+#: ../content/prenotazioni_folder.py:409
+#: ../content/validators.py:183
 msgid "You should set a start time for morning."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:398
-#: redturtle/prenotazioni/content/validators.py:199
+#: ../content/prenotazioni_folder.py:411
+#: ../content/validators.py:187
 msgid "You should set an end time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:394
-#: redturtle/prenotazioni/content/validators.py:191
+#: ../content/prenotazioni_folder.py:407
+#: ../content/validators.py:179
 msgid "You should set an end time for morning."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/stringinterp.py:124
+#: ../adapters/stringinterp.py:124
 msgid "[DEPRECATED] The booking print url with delete token."
 msgstr ""
 
 #. Default: "Leave empty, and this Booking Folder will never expire"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:182
+#: ../content/prenotazioni_folder.py:194
 msgid "aData_help"
 msgstr ""
 
 #. Default: "Book"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:199
-#: redturtle/prenotazioni/browser/vacations.py:207
+#: ../browser/prenotazione_add.py:198
+#: ../browser/vacations.py:206
 msgid "action_book"
 msgstr ""
 
 #. Default: "Cancel"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:252
-#: redturtle/prenotazioni/browser/prenotazione_move.py:147
-#: redturtle/prenotazioni/browser/vacations.py:232
+#: ../browser/prenotazione_add.py:251
+#: ../browser/prenotazione_move.py:145
+#: ../browser/vacations.py:231
 msgid "action_cancel"
 msgstr ""
 
 #. Default: "Move"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:122
+#: ../browser/prenotazione_move.py:120
 msgid "action_move"
 msgstr ""
 
 #. Default: "Search"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:250
+#: ../browser/prenotazioni_search.py:263
 msgid "action_search"
 msgstr ""
 
 #. Default: "End time in the afternoon"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:96
+#: ../content/prenotazioni_folder.py:95
 msgid "afternoon_end_label"
 msgstr ""
 
 #. Default: "Start time in the afternoon"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:90
+#: ../content/prenotazioni_folder.py:89
 msgid "afternoon_start_label"
 msgstr ""
 
 #. Default: "All"
-#: redturtle/prenotazioni/vocabularies/voc_booking_type_gates.py:16
+#: ../vocabularies/voc_booking_type_gates.py:16
 msgid "all"
 msgstr ""
 
 #. Default: "Automatically confirm."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:358
+#: ../content/prenotazioni_folder.py:371
 msgid "auto_confirm"
 msgstr ""
 
 #. Default: "All bookings will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:359
+#: ../content/prenotazioni_folder.py:372
 msgid "auto_confirm_help"
 msgstr ""
 
 #. Default: "Automatically confirmfor managers."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
+#: ../content/prenotazioni_folder.py:380
 msgid "auto_confirm_manager"
 msgstr ""
 
 #. Default: "All bookings created by Managers will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:368
+#: ../content/prenotazioni_folder.py:381
 msgid "auto_confirm_manager_help"
 msgstr ""
 
 #. Default: "End date should be greater than start."
-#: redturtle/prenotazioni/restapi/services/available_slots/get.py:44
+#: ../restapi/services/available_slots/get.py:48
 msgid "available_slots_wrong_dates"
 msgstr ""
 
 #. Default: "Please select a booking slot."
-#: redturtle/prenotazioni/browser/templates/week.pt:40
+#: ../browser/templates/week.pt:40
 msgid "book_it"
 msgstr ""
 
 #. Default: "Bookable time"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:454
+#: ../browser/templates/prenotazione_macros.pt:454
 msgid "bookable_time"
 msgstr ""
 
 #. Default: "${day}, ore ${booking_time}, prenotato da ${booked_by}, prenotazione: ${booking_type} durata: ${duration} minuti"
-#: redturtle/prenotazioni/browser/week.py:276
+#: ../browser/week.py:276
 msgid "booked_prenotation_message"
 msgstr ""
 
 #. Default: "Booking confirmed"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:456
+#: ../browser/templates/prenotazione_macros.pt:456
 msgid "booking_confirmed"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:231
-#: redturtle/prenotazioni/browser/vacations.py:204
+#: ../browser/prenotazione_add.py:230
+#: ../browser/vacations.py:203
 msgid "booking_created"
 msgstr ""
 
 #. Default: "Your booking has been deleted."
-#: redturtle/prenotazioni/browser/delete_reservation.py:114
+#: ../browser/delete_reservation.py:114
 msgid "booking_deleted_success"
 msgstr ""
 
 #. Default: "Booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:500
+#: ../content/prenotazioni_folder.py:513
 msgid "booking_fields_label"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_move.py:137
+#: ../browser/prenotazione_move.py:135
 msgid "booking_moved"
 msgstr ""
 
 #. Default: "Booking pending"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:458
+#: ../browser/templates/prenotazione_macros.pt:458
 msgid "booking_pending"
 msgstr ""
 
 #. Default: "Booking refused"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:460
+#: ../browser/templates/prenotazione_macros.pt:460
 msgid "booking_refused"
 msgstr ""
 
 #. Default: "Duration value"
-#: redturtle/prenotazioni/content/prenotazione_type.py:15
+#: ../content/prenotazione_type.py:15
 msgid "booking_type_duration_label"
 msgstr ""
 
 #. Default: "Name"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:427
+#: ../browser/templates/prenotazione_macros.pt:427
 msgid "booking_type_name"
 msgstr ""
 
 #. Default: "List of requirements to recieve the service"
-#: redturtle/prenotazioni/content/prenotazione_type.py:23
+#: ../content/prenotazione_type.py:23
 msgid "booking_type_requirements_help"
 msgstr ""
 
 #. Default: "Requirements"
-#: redturtle/prenotazioni/content/prenotazione_type.py:22
+#: ../content/prenotazione_type.py:22
 msgid "booking_type_requirements_labled"
 msgstr ""
 
 #. Default: "Value"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:428
+#: ../browser/templates/prenotazione_macros.pt:428
 msgid "booking_type_value"
 msgstr ""
 
 #. Default: "You may want to select another time slot to book one of these."
-#: redturtle/prenotazioni/browser/templates/booking_type_radio_widget.pt:77
+#: ../browser/templates/booking_type_radio_widget.pt:77
 msgid "booking_type_widget_suggest_reselect"
 msgstr ""
 
 #. Default: "The following tipologies will not fit the time you selected:"
-#: redturtle/prenotazioni/browser/templates/booking_type_radio_widget.pt:65
+#: ../browser/templates/booking_type_radio_widget.pt:65
 msgid "booking_type_widget_warn_unavailable"
 msgstr ""
 
 #. Default: "Set message text for all available notification events."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:257
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:257
 msgid "bookings_appio_templates_help"
 msgstr ""
 
 #. Default: "AppIO Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:253
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:253
 msgid "bookings_appio_templates_label"
 msgstr ""
 
 #. Default: "Set message text for all available notification events."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:266
+#: ../behaviors/booking_folder/notifications/email/__init__.py:266
 msgid "bookings_email_templates_help"
 msgstr ""
 
 #. Default: "Email Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:262
+#: ../behaviors/booking_folder/notifications/email/__init__.py:262
 msgid "bookings_email_templates_label"
 msgstr ""
 
 #. Default: "Booking limit({limit}) for the {booking_type} type is exceed for the current user"
-#: redturtle/prenotazioni/exceptions/booker.py:15
+#: ../exceptions/booker.py:15
 msgid "bookings_limit_exceeded_exception"
 msgstr ""
 
 #. Default: "Bookings not in agenda"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:111
+#: ../browser/templates/prenotazione_macros.pt:111
 msgid "bookings_not_in_agenda"
 msgstr ""
 
 #. Default: "Set message text for all available notification events. Remember that SMS has a 160 characters limit. Depending on your gateway service, it can split messages, if you exceed that limit."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:144
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:144
 msgid "bookings_sms_templates_help"
 msgstr ""
 
 #. Default: "SMS Notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:140
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:140
 msgid "bookings_sms_templates_label"
 msgstr ""
 
 #. Default: "Busy"
-#: redturtle/prenotazioni/browser/prenotazioni_context_state.py:45
+#: ../browser/prenotazioni_context_state.py:44
 msgid "busy"
 msgstr ""
 
+#. Default: "Your booking has been canceled."
+#: ../browser/prenotazione_print.py:35
+msgid "confirm_booking_canceled_message"
+msgstr ""
+
 #. Default: "Your booking has been confirmed."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:28
+#: ../browser/prenotazione_print.py:27
 msgid "confirm_booking_confirmed_message"
 msgstr ""
 
 #. Default: "Your booking has been refused."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:32
+#: ../browser/prenotazione_print.py:31
 msgid "confirm_booking_refused_message"
 msgstr ""
 
 #. Default: "Your booking has to be confirmed by the administrators."
-#: redturtle/prenotazioni/browser/prenotazione_print.py:24
+#: ../browser/prenotazione_print.py:23
 msgid "confirm_booking_waiting_message"
 msgstr ""
 
 #. Default: "Show here contacts information that will be used by authomatic mail system"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:49
+#: ../behaviors/booking_folder/contacts.py:49
 msgid "contacts_help"
 msgstr ""
 
 #. Default: "Contacts"
-#: redturtle/prenotazioni/behaviors/booking_folder/contacts.py:48
+#: ../behaviors/booking_folder/contacts.py:48
 msgid "contacts_label"
 msgstr ""
 
 #. Default: "This day is not valid."
-#: redturtle/prenotazioni/browser/vacations.py:224
+#: ../browser/vacations.py:223
 msgid "day_error"
 msgstr ""
 
 #. Default: "Day of week"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:70
+#: ../content/prenotazioni_folder.py:69
 msgid "day_label"
 msgstr ""
 
 #. Default: "You can't delete your reservation; it's too late."
-#: redturtle/prenotazioni/browser/delete_reservation.py:138
+#: ../browser/delete_reservation.py:138
 msgid "delete_expired_booking"
 msgstr ""
 
 #. Default: "Delete reservation request for: ${name}"
-#: redturtle/prenotazioni/browser/delete_reservation.py:61
+#: ../browser/delete_reservation.py:61
 msgid "delete_reservation_request"
 msgstr ""
 
 #. Default: "Unique booking code"
-#: redturtle/prenotazioni/content/prenotazione.py:181
+#: ../content/prenotazione.py:181
 msgid "description_booking_code"
 msgstr ""
 
 #. Default: "If you work for a company, please specify its name."
-#: redturtle/prenotazioni/content/prenotazione.py:161
+#: ../content/prenotazione.py:161
 msgid "description_company"
 msgstr ""
 
 #. Default: "The gate that will be unavailable"
-#: redturtle/prenotazioni/browser/vacations.py:68
+#: ../browser/vacations.py:68
 msgid "description_gate"
 msgstr ""
 
 #. Default: "This text will appear in the calendar cells"
-#: redturtle/prenotazioni/browser/vacations.py:61
+#: ../browser/vacations.py:61
 msgid "description_title"
 msgstr ""
 
 #. Default: "Foreseen booking time: ${booking_time}"
-#: redturtle/prenotazioni/browser/week.py:225
+#: ../browser/week.py:225
 msgid "foreseen_booking_time"
 msgstr ""
 
 #. Default: "${booking_time}, Orario non disponibile"
-#: redturtle/prenotazioni/browser/week.py:244
+#: ../browser/week.py:244
 msgid "foreseen_busy_time"
 msgstr ""
 
-msgid "from_label"
-msgstr ""
-
 #. Default: "You should set a start range."
-#: redturtle/prenotazioni/content/validators.py:160
+#: ../content/validators.py:148
 msgid "from_month_error"
 msgstr ""
 
 #. Default: "Selected day is too big for that month for \"from\" field."
-#: redturtle/prenotazioni/content/validators.py:167
+#: ../content/validators.py:155
 msgid "from_month_too_days_error"
 msgstr ""
 
 #. Default: "Fullname"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:55
+#: ../browser/templates/prenotazione.pt:55
 msgid "fullname"
 msgstr ""
 
 #. Default: "Limit booking in the future to an amount of days in the future starting from the current day. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:329
+#: ../content/prenotazioni_folder.py:342
 msgid "futureDays"
 msgstr ""
 
 #. Default: "Put gates here (one per line)."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:351
+#: ../content/prenotazioni_folder.py:364
 msgid "gates_help"
 msgstr ""
 
 #. Default: "Gates"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:350
+#: ../content/prenotazioni_folder.py:363
 msgid "gates_label"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazione_add.py:156
+#: ../browser/prenotazione_add.py:155
 msgid "help_prenotazione_add"
 msgstr ""
 
 #. Default: "User will not be able to add a booking unless those fields are filled. Remember that, whatever you selected in this list, users have to supply at least one of \"Email\", \"Mobile\", or \"Telephone\""
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:164
+#: ../content/prenotazioni_folder.py:176
 msgid "help_required_booking_fields"
 msgstr ""
 
 #. Default: "States if it is not allowed to reserve a booking during the current day"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:203
+#: ../content/prenotazioni_folder.py:215
 msgid "help_same_day_booking_disallowed"
 msgstr ""
 
 #. Default: "List of available reservation type for the current agenda"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:424
+#: ../browser/templates/prenotazione_macros.pt:424
 msgid "help_tipologies"
 msgstr ""
 
 #. Default: "User will not be able to add a booking unless those fields are filled. Remember that, whatever you selected in this list, users have to supply at least one of \"Email\" or \"Telephone\""
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:146
+#: ../content/prenotazioni_folder.py:158
 msgid "help_visible_booking_fields"
 msgstr ""
 
 #. Default: "Set holidays (one for line) in DD/MM/YYYY. you can write * for the year, if this event is yearly."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:304
+#: ../content/prenotazioni_folder.py:316
 msgid "holidays_help"
 msgstr ""
 
 #. Default: "Holidays"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:303
+#: ../content/prenotazioni_folder.py:315
 msgid "holidays_label"
 msgstr ""
 
 #. Default: "Booking for ${title}"
-#: redturtle/prenotazioni/adapters/ical.py:84
+#: ../adapters/ical.py:84
 msgid "ical_booking_label"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/vacations.py:32
+#: ../browser/vacations.py:32
 msgid "invalid_date"
 msgstr ""
 
 #. Default: "Invalid email address"
-#: redturtle/prenotazioni/content/prenotazione.py:32
+#: ../content/prenotazione.py:32
 msgid "invalid_email_address"
 msgstr ""
 
 #. Default: "Invalid start or end date"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:40
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:26
+#: ../browser/prenotazioni_search.py:40
+#: ../browser/stats/booking_stats.py:26
 msgid "invalid_end:search_date"
 msgstr ""
 
 #. Default: "Invalid fiscal code"
-#: redturtle/prenotazioni/content/prenotazione.py:40
+#: ../content/prenotazione.py:40
 msgid "invalid_fiscalcode"
 msgstr ""
 
 #. Default: "Invalid phone number"
-#: redturtle/prenotazioni/content/prenotazione.py:28
+#: ../content/prenotazione.py:28
 msgid "invalid_phone_number"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/vacations.py:36
+#: ../browser/vacations.py:36
 msgid "invalid_time"
 msgstr ""
 
 #. Default: "This date is past"
-#: redturtle/prenotazioni/content/prenotazione.py:36
+#: ../content/prenotazione.py:36
 msgid "is_not_future_date"
 msgstr ""
 
 #. Default: "Booking code"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:106
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:123
-#: redturtle/prenotazioni/browser/templates/prenotazione_print.pt:110
+#: ../browser/templates/delete_reservation.pt:106
+#: ../browser/templates/prenotazione.pt:123
+#: ../browser/templates/prenotazione_print.pt:110
 msgid "label_booking_code"
 msgstr ""
 
 #. Default: "Company"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:62
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:38
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:75
+#: ../browser/templates/delete_reservation.pt:62
+#: ../browser/templates/manager_notification_mail.pt:38
+#: ../browser/templates/prenotazione.pt:75
 msgid "label_booking_company"
 msgstr ""
 
 #. Default: "Booking date"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:80
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:50
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:87
+#: ../browser/templates/delete_reservation.pt:80
+#: ../browser/templates/manager_notification_mail.pt:50
+#: ../browser/templates/prenotazione.pt:87
 msgid "label_booking_date"
 msgstr ""
 
 #. Default: "${from_date} at ${at}"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:92
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:54
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:98
+#: ../browser/templates/delete_reservation.pt:92
+#: ../browser/templates/manager_notification_mail.pt:54
+#: ../browser/templates/prenotazione.pt:98
 msgid "label_booking_date_range"
 msgstr ""
 
 #. Default: "Subject"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:41
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:74
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:46
+#: ../browser/prenotazione_add.py:40
+#: ../browser/templates/delete_reservation.pt:74
+#: ../browser/templates/manager_notification_mail.pt:46
 msgid "label_booking_description"
 msgstr ""
 
 #. Default: "Email"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:50
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:30
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:63
+#: ../browser/templates/delete_reservation.pt:50
+#: ../browser/templates/manager_notification_mail.pt:30
+#: ../browser/templates/prenotazione.pt:63
 msgid "label_booking_email"
 msgstr ""
 
 #. Default: "Fiscal code"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:68
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:42
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:79
+#: ../browser/templates/delete_reservation.pt:68
+#: ../browser/templates/manager_notification_mail.pt:42
+#: ../browser/templates/prenotazione.pt:79
 msgid "label_booking_fiscalcode"
 msgstr ""
 
 #. Default: "Phone number"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:56
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:34
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:71
+#: ../browser/templates/delete_reservation.pt:56
+#: ../browser/templates/manager_notification_mail.pt:34
+#: ../browser/templates/prenotazione.pt:71
 msgid "label_booking_phone"
 msgstr ""
 
 #. Default: "Staff notes"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:113
-#: redturtle/prenotazioni/content/prenotazione.py:186
+#: ../browser/templates/prenotazione.pt:113
+#: ../content/prenotazione.py:186
 msgid "label_booking_staff_notes"
 msgstr ""
 
 #. Default: "Booking time"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:31
-#: redturtle/prenotazioni/content/prenotazione.py:126
+#: ../browser/prenotazione_move.py:30
+#: ../content/prenotazione.py:126
 msgid "label_booking_time"
 msgstr ""
 
 #. Default: "Fullname"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:38
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:22
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:52
+#: ../browser/prenotazione_add.py:37
+#: ../browser/templates/manager_notification_mail.pt:22
+#: ../browser/templates/prenotazioni_search.pt:52
 msgid "label_booking_title"
 msgstr ""
 
 #. Default: "Booking type"
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:44
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:26
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:59
+#: ../browser/templates/delete_reservation.pt:44
+#: ../browser/templates/manager_notification_mail.pt:26
+#: ../browser/templates/prenotazione.pt:59
 msgid "label_booking_type"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:293
-#: redturtle/prenotazioni/vocabularies/requirable_booking_fields.py:24
+#: ../browser/prenotazioni_search.py:306
+#: ../vocabularies/requirable_booking_fields.py:24
 msgid "label_booking_{}"
 msgstr ""
 
 #. Default: "End date"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:68
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:52
+#: ../browser/prenotazioni_search.py:68
+#: ../browser/stats/booking_stats.py:52
 msgid "label_end"
 msgstr ""
 
 #. Default: "End time"
-#: redturtle/prenotazioni/browser/vacations.py:84
+#: ../browser/vacations.py:84
 msgid "label_end_time"
 msgstr ""
 
 #. Default: "Gate"
-#: redturtle/prenotazioni/browser/prenotazione_move.py:32
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:56
-#: redturtle/prenotazioni/browser/templates/delete_reservation.pt:100
+#: ../browser/prenotazione_move.py:31
+#: ../browser/prenotazioni_search.py:56
+#: ../browser/templates/delete_reservation.pt:100
 msgid "label_gate"
 msgstr ""
 
 #. Default: "Go to the booking to see more details and manage it: ${url}"
-#: redturtle/prenotazioni/browser/templates/manager_notification_mail.pt:65
+#: ../browser/templates/manager_notification_mail.pt:65
 msgid "label_new_booking_notify_link"
 msgstr ""
 
 #. Default: "Required booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:163
+#: ../content/prenotazioni_folder.py:175
 msgid "label_required_booking_fields"
 msgstr ""
 
 #. Default: "Disallow same day booking"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:199
+#: ../content/prenotazioni_folder.py:211
 msgid "label_same_day_booking_disallowed"
 msgstr ""
 
 #. Default: "Selected date: ${date} — Time: ${slot}"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:141
+#: ../browser/prenotazione_add.py:140
 msgid "label_selected_date"
 msgstr ""
 
 #. Default: "Start date "
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:62
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:45
-#: redturtle/prenotazioni/browser/vacations.py:73
+#: ../browser/prenotazioni_search.py:62
+#: ../browser/stats/booking_stats.py:45
+#: ../browser/vacations.py:73
 msgid "label_start"
 msgstr ""
 
 #. Default: "Start time"
-#: redturtle/prenotazioni/browser/vacations.py:78
+#: ../browser/vacations.py:78
 msgid "label_start_time"
 msgstr ""
 
 #. Default: "Text to search"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:48
+#: ../browser/prenotazioni_search.py:48
 msgid "label_text"
 msgstr ""
 
 #. Default: "Reservation types"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:423
+#: ../browser/templates/prenotazione_macros.pt:423
 msgid "label_tipologies"
 msgstr ""
 
 #. Default: "Title"
-#: redturtle/prenotazioni/browser/vacations.py:60
+#: ../browser/vacations.py:60
 msgid "label_title"
 msgstr ""
 
 #. Default: "User"
-#: redturtle/prenotazioni/browser/stats/booking_stats.py:43
+#: ../browser/stats/booking_stats.py:43
 msgid "label_user"
 msgstr ""
 
 #. Default: "Visible booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:145
+#: ../content/prenotazioni_folder.py:157
 msgid "label_visible_booking_fields"
 msgstr ""
 
 #. Default: "Legend"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:447
+#: ../browser/templates/prenotazione_macros.pt:447
 msgid "legend"
 msgstr ""
 
 #. Default: "Short description of available action for the booking board"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:448
+#: ../browser/templates/prenotazione_macros.pt:448
 msgid "legend_description"
 msgstr ""
 
 #. Default: "The minimum value of a single slot is 5 minutes. You cannot book a reservation when the needed time exceeds the available time."
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:469
+#: ../browser/templates/prenotazione_macros.pt:469
 msgid "legend_note"
 msgstr ""
 
 #. Default: "The number of simultaneous bookings allowed for the same user."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:449
+#: ../content/prenotazioni_folder.py:462
 msgid "max_bookings_allowed_description"
 msgstr ""
 
 #. Default: "Maximum bookings number allowed"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:445
+#: ../content/prenotazioni_folder.py:458
 msgid "max_bookings_allowed_label"
 msgstr ""
 
 #. Default: "Unable to find a booking with the givend id: ${uid}."
-#: redturtle/prenotazioni/browser/delete_reservation.py:44
+#: ../browser/delete_reservation.py:44
 msgid "missing_booking"
 msgstr ""
 
 #. Default: "You need to provide a reservation id."
-#: redturtle/prenotazioni/browser/delete_reservation.py:38
+#: ../browser/delete_reservation.py:38
 msgid "missing_uid"
 msgstr ""
 
-msgid "month_label"
-msgstr ""
-
 #. Default: "End time in the morning"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:84
+#: ../content/prenotazioni_folder.py:83
 msgid "morning_end_label"
 msgstr ""
 
 #. Default: "Start time in the morning"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:79
+#: ../content/prenotazioni_folder.py:78
 msgid "morning_start_label"
 msgstr ""
 
 #. Default: "Go back to the calendar"
-#: redturtle/prenotazioni/browser/prenotazioni_search.py:260
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:192
-#: redturtle/prenotazioni/browser/templates/prenotazione_add.pt:127
+#: ../browser/prenotazioni_search.py:273
+#: ../browser/templates/prenotazione.pt:192
+#: ../browser/templates/prenotazione_add.pt:127
 msgid "move_back_message"
 msgstr ""
 
 #. Default: "Move booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:163
+#: ../browser/templates/prenotazione.pt:163
 msgid "move_booking"
 msgstr ""
 
 #. Default: "Please move this booking into a new available slot or"
-#: redturtle/prenotazioni/browser/templates/prenotazione_move.pt:39
+#: ../browser/templates/prenotazione_move.pt:39
 msgid "move_message"
 msgstr ""
 
 #. Default: "next week"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:39
+#: ../browser/templates/prenotazione_macros.pt:39
 msgid "next-week"
 msgstr ""
 
 #. Default: "Booking is not allowed before the amount of days specified. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:341
+#: ../content/prenotazioni_folder.py:354
 msgid "notBeforeDays"
 msgstr ""
 
 #. Default: "Enable AppIO notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:123
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:123
 msgid "notifications_appio_enabled_help"
 msgstr ""
 
 #. Default: "AppIO notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:122
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:122
 msgid "notifications_appio_enabled_label"
 msgstr ""
 
 #. Default: "Enable Email notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:123
+#: ../behaviors/booking_folder/notifications/email/__init__.py:123
 msgid "notifications_email_enabled_help"
 msgstr ""
 
 #. Default: "Email notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:122
+#: ../behaviors/booking_folder/notifications/email/__init__.py:122
 msgid "notifications_email_enabled_label"
 msgstr ""
 
 #. Default: "Notifications"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:508
+#: ../content/prenotazioni_folder.py:521
 msgid "notifications_label"
 msgstr ""
 
 #. Default: "Enable SMS notifications."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:70
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:70
 msgid "notifications_sms_enabled_help"
 msgstr ""
 
 #. Default: "SMS notifications"
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:69
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:69
 msgid "notifications_sms_enabled_label"
 msgstr ""
 
 #. Default: "This is an automatic reminder about your booking on ${date} for ${booking_type}.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:111
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:111
 msgid "notify_as_reminder_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking reminder on ${booking_date}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:101
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:101
 msgid "notify_as_reminder_appio_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:231
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:231
 msgid "notify_as_reminder_appio_subject_help"
 msgstr ""
 
 #. Default: "[Reminder] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:239
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:248
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:126
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:239
+#: ../behaviors/booking_folder/notifications/email/__init__.py:248
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:126
 msgid "notify_as_reminder_message"
 msgstr ""
 
 #. Default: "This is an automatic reminder about your booking on ${date} for ${booking_type}.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:111
+#: ../behaviors/booking_folder/notifications/email/__init__.py:111
 msgid "notify_as_reminder_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:243
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:252
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:130
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:243
+#: ../behaviors/booking_folder/notifications/email/__init__.py:252
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:130
 msgid "notify_as_reminder_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: This is an automatic reminder about your booking on ${date} for ${booking_type}.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:58
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:58
 msgid "notify_as_reminder_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Reminder] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:227
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:236
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:227
+#: ../behaviors/booking_folder/notifications/email/__init__.py:236
 msgid "notify_as_reminder_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking reminder on ${booking_date}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:101
+#: ../behaviors/booking_folder/notifications/email/__init__.py:101
 msgid "notify_as_reminder_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a reminder will be sent."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:240
+#: ../behaviors/booking_folder/notifications/email/__init__.py:240
 msgid "notify_as_reminder_subject_help"
 msgstr ""
 
 #. Default: "Notify when confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:418
+#: ../content/prenotazioni_folder.py:431
 msgid "notify_on_confirm"
 msgstr ""
 
 #. Default: "The booking ${booking_type} for ${title} has been confirmed.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:48
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:48
 msgid "notify_on_confirm_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking of ${booking_date} at ${booking_time} was accepted"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:38
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:38
 msgid "notify_on_confirm_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:419
+#: ../content/prenotazioni_folder.py:432
 msgid "notify_on_confirm_help"
 msgstr ""
 
 #. Default: "[Confirmed] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:167
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:176
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:90
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:167
+#: ../behaviors/booking_folder/notifications/email/__init__.py:176
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:90
 msgid "notify_on_confirm_message"
 msgstr ""
 
 #. Default: "The booking ${booking_type} for ${title} has been confirmed.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:48
+#: ../behaviors/booking_folder/notifications/email/__init__.py:48
 msgid "notify_on_confirm_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been confirmed."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:171
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:180
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:94
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:171
+#: ../behaviors/booking_folder/notifications/email/__init__.py:180
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:94
 msgid "notify_on_confirm_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: Booking of ${booking_date} at ${booking_time} has been accepted.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:28
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:28
 msgid "notify_on_confirm_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Confirm] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:155
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:164
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:155
+#: ../behaviors/booking_folder/notifications/email/__init__.py:164
 msgid "notify_on_confirm_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking of ${booking_date} at ${booking_time} was accepted"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:38
+#: ../behaviors/booking_folder/notifications/email/__init__.py:38
 msgid "notify_on_confirm_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been confirmed."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:159
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:168
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:159
+#: ../behaviors/booking_folder/notifications/email/__init__.py:168
 msgid "notify_on_confirm_subject_help"
 msgstr ""
 
 #. Default: "Notify when moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:427
+#: ../content/prenotazioni_folder.py:440
 msgid "notify_on_move"
 msgstr ""
 
 #. Default: "The booking scheduling for ${booking_type} was modified.<br/><br/>The new one is on ${booking_date} at ${booking_time}.<br/><br/>You can see details and print a reminder following this [link](${booking_print_url})."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:69
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:69
 msgid "notify_on_move_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking date modified for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:59
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:59
 msgid "notify_on_move_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:428
+#: ../content/prenotazioni_folder.py:441
 msgid "notify_on_move_help"
 msgstr ""
 
 #. Default: "[Move] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:191
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:200
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:102
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:191
+#: ../behaviors/booking_folder/notifications/email/__init__.py:200
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:102
 msgid "notify_on_move_message"
 msgstr ""
 
 #. Default: "The booking scheduling for ${booking_type} was modified.<br/><br/>The new one is on ${booking_date} at ${booking_time}.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:69
+#: ../behaviors/booking_folder/notifications/email/__init__.py:69
 msgid "notify_on_move_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been moved."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:195
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:204
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:106
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:195
+#: ../behaviors/booking_folder/notifications/email/__init__.py:204
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:106
 msgid "notify_on_move_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: The booking scheduling for ${booking_type} was modified.\nThe new one is on ${booking_date} at ${booking_time}.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:38
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:38
 msgid "notify_on_move_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Move] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:179
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:188
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:179
+#: ../behaviors/booking_folder/notifications/email/__init__.py:188
 msgid "notify_on_move_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking date modified for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:59
+#: ../behaviors/booking_folder/notifications/email/__init__.py:59
 msgid "notify_on_move_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been moved."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:183
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:192
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:183
+#: ../behaviors/booking_folder/notifications/email/__init__.py:192
 msgid "notify_on_move_subject_help"
 msgstr ""
 
 #. Default: "Notify when rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
+#: ../content/prenotazioni_folder.py:449
 msgid "notify_on_refuse"
 msgstr ""
 
 #. Default: "The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:91
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:91
 msgid "notify_on_refuse_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking refused for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:81
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:81
 msgid "notify_on_refuse_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:437
+#: ../content/prenotazioni_folder.py:450
 msgid "notify_on_refuse_help"
 msgstr ""
 
 #. Default: "[Refuse] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:215
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:224
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:114
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:215
+#: ../behaviors/booking_folder/notifications/email/__init__.py:224
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:114
 msgid "notify_on_refuse_message"
 msgstr ""
 
 #. Default: "The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:91
+#: ../behaviors/booking_folder/notifications/email/__init__.py:91
 msgid "notify_on_refuse_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:219
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:228
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:118
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:219
+#: ../behaviors/booking_folder/notifications/email/__init__.py:228
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:118
 msgid "notify_on_refuse_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: The booking ${booking_type} of ${booking_date} at ${booking_time} was refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:48
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:48
 msgid "notify_on_refuse_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Refuse] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:203
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:212
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:203
+#: ../behaviors/booking_folder/notifications/email/__init__.py:212
 msgid "notify_on_refuse_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking refused for ${title}"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:81
+#: ../behaviors/booking_folder/notifications/email/__init__.py:81
 msgid "notify_on_refuse_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been refused."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:207
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:216
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:207
+#: ../behaviors/booking_folder/notifications/email/__init__.py:216
 msgid "notify_on_refuse_subject_help"
 msgstr ""
 
 #. Default: "Notify when created."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:409
+#: ../content/prenotazioni_folder.py:422
 msgid "notify_on_submit"
 msgstr ""
 
 #. Default: "Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.<br/><br/>You can see details and print a reminder following this [${booking_print_url}](link)."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:28
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:28
 msgid "notify_on_submit_appio_message_default_value"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking created"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:18
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:18
 msgid "notify_on_submit_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been created. If auto-confirm flag is selected and confirm notify is selected, this one will be ignored."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:410
+#: ../content/prenotazioni_folder.py:423
 msgid "notify_on_submit_help"
 msgstr ""
 
 #. Default: "[Created] message"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:143
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:152
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:78
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:143
+#: ../behaviors/booking_folder/notifications/email/__init__.py:152
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:78
 msgid "notify_on_submit_message"
 msgstr ""
 
 #. Default: "Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.<br/><br/>You can see details and print a reminder following this <a href=${booking_print_url}>link</a>."
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:28
+#: ../behaviors/booking_folder/notifications/email/__init__.py:28
 msgid "notify_on_submit_message_default_value"
 msgstr ""
 
 #. Default: "The message text when a booking has been created."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:147
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:156
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:82
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:147
+#: ../behaviors/booking_folder/notifications/email/__init__.py:156
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:82
 msgid "notify_on_submit_message_help"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}]: Booking ${booking_type} for ${booking_date} at ${booking_time} has been created.\nSee details or delete it: ${booking_print_url}."
-#: redturtle/prenotazioni/behaviors/booking_folder/sms/__init__.py:18
+#: ../behaviors/booking_folder/notifications/sms/__init__.py:18
 msgid "notify_on_submit_sms_message_default_value"
 msgstr ""
 
 #. Default: "[Created] subject"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:131
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:140
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:131
+#: ../behaviors/booking_folder/notifications/email/__init__.py:140
 msgid "notify_on_submit_subject"
 msgstr ""
 
 #. Default: "[${prenotazioni_folder_title}] Booking created"
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:18
+#: ../behaviors/booking_folder/notifications/email/__init__.py:18
 msgid "notify_on_submit_subject_default_value"
 msgstr ""
 
 #. Default: "The message subject when a booking has been created."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:135
-#: redturtle/prenotazioni/behaviors/booking_folder/email/__init__.py:144
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:135
+#: ../behaviors/booking_folder/notifications/email/__init__.py:144
 msgid "notify_on_submit_subject_help"
 msgstr ""
 
 #. Default: "Pause end"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:125
+#: ../content/prenotazioni_folder.py:124
 msgid "pause_end_label"
 msgstr ""
 
 #. Default: "Pause start"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:120
+#: ../content/prenotazioni_folder.py:119
 msgid "pause_start_label"
 msgstr ""
 
 #. Default: "Please select a time slot"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:280
+#: ../browser/prenotazione_add.py:279
 msgid "please_pick_a_date"
 msgstr ""
 
 #. Default: "${day}, ore ${booking_time}"
-#: redturtle/prenotazioni/browser/week.py:256
+#: ../browser/week.py:256
 msgid "prenotation_slot_message"
 msgstr ""
 
 #. Default: "prenotazioni_search"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "prenotazioni_search"
 msgstr ""
 
 #. Default: "previous week"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:14
+#: ../browser/templates/prenotazione_macros.pt:14
 msgid "previous-week"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:31
+#: ../configure.zcml:31
 msgid "redturtle.prenotazioni"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:48
+#: ../configure.zcml:48
 msgid "redturtle.prenotazioni (to_1500)"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:40
-#: redturtle/prenotazioni/staging/configure.zcml:25
+#: ../configure.zcml:56
+msgid "redturtle.prenotazioni (to_2005)"
+msgstr ""
+
+#: ../configure.zcml:40
+#: ../demo/configure.zcml:25
 msgid "redturtle.prenotazioni (uninstall)"
 msgstr ""
 
-#: redturtle/prenotazioni/configure.zcml:48
+#: ../configure.zcml:48
 msgid "redturtle.prenotazioni to 1500."
 msgstr ""
 
-#: redturtle/prenotazioni/staging/configure.zcml:16
-msgid "redturtle.prenotazioni.staging"
+#: ../configure.zcml:56
+msgid "redturtle.prenotazioni to 2005."
+msgstr ""
+
+#: ../demo/configure.zcml:16
+msgid "redturtle.prenotazioni.demo"
 msgstr ""
 
 #. Default: "The booking state is \"refused\". If you change it, the booking time may conflict with another one."
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:30
+#: ../browser/templates/prenotazione.pt:30
 msgid "refused-review-state-warning"
 msgstr ""
 
 #. Default: "Reject booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:176
+#: ../browser/templates/prenotazione.pt:176
 msgid "reject_booking"
 msgstr ""
 
 #. Default: "Set how many days before of a booking date the user will be notified about it."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:461
+#: ../content/prenotazioni_folder.py:474
 msgid "reminder_notification_gap_description"
 msgstr ""
 
 #. Default: "Booking reminder days"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:457
+#: ../content/prenotazioni_folder.py:470
 msgid "reminder_notification_gap_label"
 msgstr ""
 
 #. Default: "Code"
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:58
+#: ../browser/templates/prenotazioni_search.pt:58
 msgid "reservation_code"
 msgstr ""
 
 #. Default: "Reservation date"
-#: redturtle/prenotazioni/browser/templates/prenotazione_move.pt:33
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:57
+#: ../browser/templates/prenotazione_move.pt:33
+#: ../browser/templates/prenotazioni_search.pt:57
 msgid "reservation_date"
 msgstr ""
 
 #. Default: "Booking request for: ${name}"
-#: redturtle/prenotazioni/browser/prenotazione_print.py:44
+#: ../browser/prenotazione_print.py:47
 msgid "reservation_request"
 msgstr ""
 
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:30
+#: ../browser/templates/prenotazione_macros.pt:30
 msgid "resize"
 msgstr ""
 
 #. Default: "items matching your search terms."
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:30
+#: ../browser/templates/prenotazioni_search.pt:30
 msgid "result_number"
 msgstr ""
 
 #. Default: "You need to provide a booking date to get the schema and available types."
-#: redturtle/prenotazioni/restapi/services/booking_schema/get.py:71
+#: ../restapi/services/booking_schema/get.py:71
 msgid "schema_missing_date"
 msgstr ""
 
 #. Default: "Search by gate"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:465
+#: ../browser/templates/prenotazione_macros.pt:465
 msgid "search-by-gate"
 msgstr ""
 
 #. Default: "Search result"
-#: redturtle/prenotazioni/browser/templates/prenotazioni_search.pt:12
+#: ../browser/templates/prenotazioni_search.pt:12
 msgid "search_result_message"
 msgstr ""
 
 #. Default: "seleziona l'opzione desiderata dal gruppo di radio button seguente"
-#: redturtle/prenotazioni/browser/z3c_custom_widget.py:153
+#: ../browser/z3c_custom_widget.py:153
 msgid "select-option"
 msgstr ""
 
 #. Default: "AppIO service code related to the current booking type"
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:293
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:293
 msgid "service_code_help"
 msgstr ""
 
 #. Default: "AppIO service code."
-#: redturtle/prenotazioni/behaviors/booking_folder/appio/__init__.py:289
+#: ../behaviors/booking_folder/notifications/appio/__init__.py:289
 msgid "service_code_label"
 msgstr ""
 
 #. Default: "This gate has some booking schedule in this time period."
-#: redturtle/prenotazioni/browser/vacations.py:217
+#: ../browser/vacations.py:216
 msgid "slot_conflict_error"
 msgstr ""
 
 #. Default: "You cannot book any booking_type at this time"
-#: redturtle/prenotazioni/browser/prenotazione_add.py:284
+#: ../browser/prenotazione_add.py:283
 msgid "time_slot_to_short"
 msgstr ""
 
-msgid "to_label"
-msgstr ""
-
 #. Default: "You should set an end range."
-#: redturtle/prenotazioni/content/validators.py:175
+#: ../content/validators.py:163
 msgid "to_month_error"
 msgstr ""
 
 #. Default: "Selected day is too big for that month for \"to\" field."
-#: redturtle/prenotazioni/content/validators.py:182
+#: ../content/validators.py:170
 msgid "to_month_too_days_error"
 msgstr ""
 
 #. Default: "You can't add a booking with type '${booking_type}'."
-#: redturtle/prenotazioni/restapi/services/booking/add.py:89
+#: ../restapi/services/booking/add.py:134
 msgid "unauthorized_add_vacation"
 msgstr ""
 
 #. Default: "Unbookable time"
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:452
+#: ../browser/templates/prenotazione_macros.pt:452
 msgid "unbookable_time"
 msgstr ""
 
 #. Default: "vacation_booking"
-#: redturtle/prenotazioni/profiles/default/actions.xml
+#: ../profiles/default/actions.xml
 msgid "vacation_booking"
 msgstr ""
 
 #. Default: "View booking"
-#: redturtle/prenotazioni/browser/templates/prenotazione.pt:143
-#: redturtle/prenotazioni/browser/templates/prenotazione_macros.pt:463
+#: ../browser/templates/prenotazione.pt:143
+#: ../browser/templates/prenotazione_macros.pt:463
 msgid "view_booking"
 msgstr ""
 
 #. Default: "Insert here week schema for some custom date intervals."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:281
+#: ../content/prenotazioni_folder.py:293
 msgid "week_table_overrides_help"
 msgstr ""
 
 #. Default: "Week table overrides"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:280
+#: ../content/prenotazioni_folder.py:292
 msgid "week_table_overrides_label"
 msgstr ""
 
 #. Default: "You tried to delete booking with a wrong action."
-#: redturtle/prenotazioni/browser/delete_reservation.py:97
+#: ../browser/delete_reservation.py:97
 msgid "wrong_authenticator"
 msgstr ""

--- a/src/redturtle/prenotazioni/prenotazione_event.py
+++ b/src/redturtle/prenotazioni/prenotazione_event.py
@@ -5,13 +5,11 @@ from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
 class IMovedPrenotazione(IObjectModifiedEvent):
-
     """Marker interface for prenotazione that is moved"""
 
 
 @implementer(IMovedPrenotazione)
 class MovedPrenotazione(ObjectModifiedEvent):
-
     """Event fired when a prenotazione that is moved"""
 
     def __init__(self, obj):

--- a/src/redturtle/prenotazioni/profiles/default/metadata.xml
+++ b/src/redturtle/prenotazioni/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2005</version>
+  <version>2006</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/redturtle/prenotazioni/profiles/default/workflows/prenotazioni_workflow/definition.xml
+++ b/src/redturtle/prenotazioni/profiles/default/workflows/prenotazioni_workflow/definition.xml
@@ -245,7 +245,7 @@
   </transition>
   <transition after_script=""
               before_script=""
-              new_state="refused"
+              new_state="canceled"
               title="Rifiuta"
               transition_id="cancel"
               trigger="USER"

--- a/src/redturtle/prenotazioni/profiles/default/workflows/prenotazioni_workflow/definition.xml
+++ b/src/redturtle/prenotazioni/profiles/default/workflows/prenotazioni_workflow/definition.xml
@@ -17,6 +17,7 @@
     <description>Waiting to be reviewed, not editable by the owner and not visible</description>
     <exit-transition transition_id="confirm" />
     <exit-transition transition_id="refuse" />
+    <exit-transition transition_id="cancel" />
     <permission-map acquired="False"
                     name="Access contents information"
     >
@@ -97,8 +98,9 @@
   <state state_id="confirmed"
          title="Confermato"
   >
-    <exit-transition transition_id="refuse" />
-    <permission-map acquired="False"
+  <exit-transition transition_id="refuse" />
+  <exit-transition transition_id="cancel" />
+  <permission-map acquired="False"
                     name="Access contents information"
     >
       <permission-role>Owner</permission-role>
@@ -172,6 +174,45 @@
       <permission-role>Bookings Manager</permission-role>
     </permission-map>
   </state>
+  <state state_id="canceled"
+         title="Annullato"
+  >
+    <exit-transition transition_id="restore" />
+    <permission-map acquired="False"
+                    name="Access contents information"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Modify portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="View"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Review portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+  </state>  
   <transition after_script=""
               before_script=""
               new_state="confirmed"
@@ -198,6 +239,21 @@
             icon=""
             url="%(content_url)s/content_status_modify?workflow_action=refuse"
     >Rifiuta</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </transition>
+  <transition after_script=""
+              before_script=""
+              new_state="refused"
+              title="Rifiuta"
+              transition_id="cancel"
+              trigger="USER"
+  >
+    <action category="workflow"
+            icon=""
+            url="%(content_url)s/content_status_modify?workflow_action=cancel"
+    >Annulla</action>
     <guard>
       <guard-permission>Review portal content</guard-permission>
     </guard>

--- a/src/redturtle/prenotazioni/profiles/to_2006/metadata.xml
+++ b/src/redturtle/prenotazioni/profiles/to_2006/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <version>2006</version>
+</metadata>

--- a/src/redturtle/prenotazioni/profiles/to_2006/prenotazioni_workflow/definition.xml
+++ b/src/redturtle/prenotazioni/profiles/to_2006/prenotazioni_workflow/definition.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dc-workflow description="Workflow for Prenotazione content type"
+             initial_state="private"
+             manager_bypass="False"
+             state_variable="review_state"
+             title="Prenotazioni Workflow"
+             workflow_id="prenotazioni_workflow"
+>
+  <permission>Access contents information</permission>
+  <permission>Modify portal content</permission>
+  <permission>View</permission>
+  <permission>Review portal content</permission>
+  <permission>redturtle.prenotazioni: Manage Prenotazioni</permission>
+  <state state_id="pending"
+         title="In attesa"
+  >
+    <description>Waiting to be reviewed, not editable by the owner and not visible</description>
+    <exit-transition transition_id="confirm" />
+    <exit-transition transition_id="refuse" />
+    <exit-transition transition_id="cancel" />
+    <permission-map acquired="False"
+                    name="Access contents information"
+    >
+      <permission-role>Owner</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Modify portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="View"
+    >
+      <permission-role>Owner</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Review portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+  </state>
+  <state state_id="private"
+         title="Private"
+  >
+    <description>Fake initial state, immediately changed</description>
+    <exit-transition transition_id="submit" />
+    <permission-map acquired="False"
+                    name="Access contents information"
+    >
+      <permission-role>Anonymous</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Modify portal content"
+    >
+      <permission-role>Anonymous</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="View"
+    >
+      <permission-role>Anonymous</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Review portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+  </state>
+  <state state_id="confirmed"
+         title="Confermato"
+  >
+  <exit-transition transition_id="refuse" />
+  <exit-transition transition_id="cancel" />
+  <permission-map acquired="False"
+                    name="Access contents information"
+    >
+      <permission-role>Owner</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Modify portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="View"
+    >
+      <permission-role>Owner</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Review portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+  </state>
+  <state state_id="refused"
+         title="Rifiutato"
+  >
+    <exit-transition transition_id="restore" />
+    <permission-map acquired="False"
+                    name="Access contents information"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Modify portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="View"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Review portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+  </state>
+  <state state_id="canceled"
+         title="Annullato"
+  >
+    <exit-transition transition_id="restore" />
+    <permission-map acquired="False"
+                    name="Access contents information"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Modify portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="View"
+    >
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+    <permission-map acquired="False"
+                    name="Review portal content"
+    >
+      <permission-role>Manager</permission-role>
+      <permission-role>Reviewer</permission-role>
+      <permission-role>Bookings Manager</permission-role>
+    </permission-map>
+  </state>  
+  <transition after_script=""
+              before_script=""
+              new_state="confirmed"
+              title="Conferma"
+              transition_id="confirm"
+              trigger="USER"
+  >
+    <action category="workflow"
+            icon=""
+            url="%(content_url)s/content_status_modify?workflow_action=confirm"
+    >Conferma</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </transition>
+  <transition after_script=""
+              before_script=""
+              new_state="refused"
+              title="Rifiuta"
+              transition_id="refuse"
+              trigger="USER"
+  >
+    <action category="workflow"
+            icon=""
+            url="%(content_url)s/content_status_modify?workflow_action=refuse"
+    >Rifiuta</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </transition>
+  <transition after_script=""
+              before_script=""
+              new_state="refused"
+              title="Rifiuta"
+              transition_id="cancel"
+              trigger="USER"
+  >
+    <action category="workflow"
+            icon=""
+            url="%(content_url)s/content_status_modify?workflow_action=cancel"
+    >Annulla</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </transition>
+  <transition after_script=""
+              before_script=""
+              new_state="pending"
+              title="Ripristina"
+              transition_id="restore"
+              trigger="USER"
+  >
+    <action category="workflow"
+            icon=""
+            url="%(content_url)s/content_status_modify?workflow_action=restore"
+    >Ripristina</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </transition>
+  <transition after_script=""
+              before_script=""
+              new_state="pending"
+              title="Transazione automatica di richiesta conferma"
+              transition_id="submit"
+              trigger="USER"
+  >
+
+    <guard>
+      <guard-permission>View</guard-permission>
+    </guard>
+  </transition>
+  <worklist title=""
+            worklist_id="reviewer_queue"
+  >
+    <description>Reviewer tasks</description>
+    <action category="global"
+            icon=""
+            url="%(portal_url)s/search?review_state=pending"
+    >Pending (%(count)d)</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+    <match name="review_state"
+           values="pending"
+    />
+  </worklist>
+  <variable for_catalog="False"
+            for_status="True"
+            update_always="True"
+            variable_id="action"
+  >
+    <description>Previous transition</description>
+    <default>
+
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+</guard>
+  </variable>
+  <variable for_catalog="False"
+            for_status="True"
+            update_always="True"
+            variable_id="actor"
+  >
+    <description>The ID of the user who performed the previous transition</description>
+    <default>
+
+      <expression>user/getUserName</expression>
+    </default>
+    <guard>
+</guard>
+  </variable>
+  <variable for_catalog="False"
+            for_status="True"
+            update_always="True"
+            variable_id="comments"
+  >
+    <description>Comment about the last transition</description>
+    <default>
+
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+</guard>
+  </variable>
+  <variable for_catalog="False"
+            for_status="False"
+            update_always="False"
+            variable_id="review_history"
+  >
+    <description>Provides access to workflow history</description>
+    <default>
+
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+      <guard-permission>Request review</guard-permission>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </variable>
+  <variable for_catalog="False"
+            for_status="True"
+            update_always="True"
+            variable_id="time"
+  >
+    <description>When the previous transition was performed</description>
+    <default>
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+</guard>
+  </variable>
+</dc-workflow>

--- a/src/redturtle/prenotazioni/profiles/to_2006/workflows.xml
+++ b/src/redturtle/prenotazioni/profiles/to_2006/workflows.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object meta_type="Plone Workflow Tool"
+        name="portal_workflow"
+>
+  <property name="title">Contains workflow definitions for your portal</property>
+  <object meta_type="Workflow"
+          name="prenotazioni_workflow"
+  />
+</object>

--- a/src/redturtle/prenotazioni/profiles/to_2006/workflows/prenotazioni_workflow/definition.xml
+++ b/src/redturtle/prenotazioni/profiles/to_2006/workflows/prenotazioni_workflow/definition.xml
@@ -245,7 +245,7 @@
   </transition>
   <transition after_script=""
               before_script=""
-              new_state="refused"
+              new_state="canceled"
               title="Rifiuta"
               transition_id="cancel"
               trigger="USER"

--- a/src/redturtle/prenotazioni/restapi/services/booking/delete.py
+++ b/src/redturtle/prenotazioni/restapi/services/booking/delete.py
@@ -22,15 +22,20 @@ class DeleteBooking(Service):
             booking = api.content.get(UID=self.booking_uid)
             if not booking:
                 return self.reply_no_content(status=404)
-
-        self.request.form["uid"] = self.booking_uid
-        delete_view = api.content.get_view(
-            name="confirm-delete",
-            context=booking.getPrenotazioniFolder(),
-            request=self.request,
-        )
-        res = delete_view.do_delete()
-        if not res:
-            # ok
+            # TODO: refuse only confirmed or pending bookings
+            if api.content.get_state(booking) not in ("confirmed", "pending"):
+                raise BadRequest("Cannot cancel this booking")
+            api.content.transition(booking, "cancel")
             return self.reply_no_content()
-        raise BadRequest(res.get("error", ""))
+
+        # self.request.form["uid"] = self.booking_uid
+        # delete_view = api.content.get_view(
+        #     name="confirm-delete",
+        #     context=booking.getPrenotazioniFolder(),
+        #     request=self.request,
+        # )
+        # res = delete_view.do_delete()
+        # if not res:
+        #     # ok
+        #     return self.reply_no_content()
+        # raise BadRequest(res.get("error", ""))

--- a/src/redturtle/prenotazioni/restapi/services/booking/delete.py
+++ b/src/redturtle/prenotazioni/restapi/services/booking/delete.py
@@ -22,15 +22,15 @@ class DeleteBooking(Service):
             booking = api.content.get(UID=self.booking_uid)
             if not booking:
                 return self.reply_no_content(status=404)
-            # TODO: refuse only confirmed or pending bookings
-            self.request.form["uid"] = self.booking_uid
-            delete_view = api.content.get_view(
-                name="confirm-delete",
-                context=booking.getPrenotazioniFolder(),
-                request=self.request,
-            )
-            res = delete_view.do_delete()
-            if not res:
-                # ok
-                return self.reply_no_content()
-            raise BadRequest(res.get("error", ""))
+        # TODO: refuse only confirmed or pending bookings
+        self.request.form["uid"] = self.booking_uid
+        delete_view = api.content.get_view(
+            name="confirm-delete",
+            context=booking.getPrenotazioniFolder(),
+            request=self.request,
+        )
+        res = delete_view.do_delete()
+        if not res:
+            # ok
+            return self.reply_no_content()
+        raise BadRequest(res.get("error", ""))

--- a/src/redturtle/prenotazioni/restapi/services/booking/delete.py
+++ b/src/redturtle/prenotazioni/restapi/services/booking/delete.py
@@ -4,6 +4,7 @@ from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
+# from redturtle.prenotazioni import _
 
 
 @implementer(IPublishTraverse)
@@ -25,7 +26,7 @@ class DeleteBooking(Service):
             # TODO: refuse only confirmed or pending bookings
             if api.content.get_state(booking) not in ("confirmed", "pending"):
                 raise BadRequest("Cannot cancel this booking")
-            api.content.transition(booking, "cancel")
+            api.content.transition(booking, "cancel")  # , comment=_("Booking canceled"))
             return self.reply_no_content()
 
         # self.request.form["uid"] = self.booking_uid

--- a/src/redturtle/prenotazioni/restapi/services/booking/delete.py
+++ b/src/redturtle/prenotazioni/restapi/services/booking/delete.py
@@ -4,7 +4,6 @@ from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
-# from redturtle.prenotazioni import _
 
 
 @implementer(IPublishTraverse)
@@ -24,19 +23,14 @@ class DeleteBooking(Service):
             if not booking:
                 return self.reply_no_content(status=404)
             # TODO: refuse only confirmed or pending bookings
-            if api.content.get_state(booking) not in ("confirmed", "pending"):
-                raise BadRequest("Cannot cancel this booking")
-            api.content.transition(booking, "cancel")  # , comment=_("Booking canceled"))
-            return self.reply_no_content()
-
-        # self.request.form["uid"] = self.booking_uid
-        # delete_view = api.content.get_view(
-        #     name="confirm-delete",
-        #     context=booking.getPrenotazioniFolder(),
-        #     request=self.request,
-        # )
-        # res = delete_view.do_delete()
-        # if not res:
-        #     # ok
-        #     return self.reply_no_content()
-        # raise BadRequest(res.get("error", ""))
+            self.request.form["uid"] = self.booking_uid
+            delete_view = api.content.get_view(
+                name="confirm-delete",
+                context=booking.getPrenotazioniFolder(),
+                request=self.request,
+            )
+            res = delete_view.do_delete()
+            if not res:
+                # ok
+                return self.reply_no_content()
+            raise BadRequest(res.get("error", ""))

--- a/src/redturtle/prenotazioni/tests/test_delete_booking.py
+++ b/src/redturtle/prenotazioni/tests/test_delete_booking.py
@@ -99,7 +99,7 @@ class TestDeleteBooking(unittest.TestCase):
         res = self.view.do_delete()
 
         self.assertIsNone(res)
-        self.assertIsNone(api.content.get(UID=uid))
+        self.assertEqual(api.content.get_state(api.content.get(UID=uid)), "canceled")
 
     @unittest.skip("wip")
     def test_anon_cant_delete_other_user_booking(self):
@@ -137,10 +137,9 @@ class TestDeleteBooking(unittest.TestCase):
         res = self.view.do_delete()
 
         self.assertIsNone(res)
-        self.assertEqual(
-            len(self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)),
-            0,
-        )
+        # the booking is marked as canceled
+        brains = self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)
+        self.assertEqual([brain.review_state for brain in brains], ["canceled"])
 
     def test_user_can_delete_his_booking(self):
         login(self.portal, "user")
@@ -161,10 +160,9 @@ class TestDeleteBooking(unittest.TestCase):
         res = self.view.do_delete()
 
         self.assertIsNone(res)
-        self.assertEqual(
-            len(self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)),
-            0,
-        )
+        # the booking is marked as canceled
+        brains = self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)
+        self.assertEqual([brain.review_state for brain in brains], ["canceled"])
 
     @unittest.skip("wip")
     def test_user_cant_delete_other_user_booking(self):

--- a/src/redturtle/prenotazioni/tests/test_delete_booking_api.py
+++ b/src/redturtle/prenotazioni/tests/test_delete_booking_api.py
@@ -129,7 +129,8 @@ class TestDeleteBookingApi(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertIsNone(api.content.get(UID=uid))
+        brains = self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)
+        self.assertEqual([brain.review_state for brain in brains], ["canceled"])
 
     @unittest.skip("wip")
     def test_anon_cant_delete_other_user_booking(self):
@@ -148,7 +149,8 @@ class TestDeleteBookingApi(unittest.TestCase):
         response = self.get_response(session=self.api_session_anon, uid=uid)
 
         self.assertEqual(response.status_code, 401)
-        self.assertIsNotNone(api.content.get(UID=uid))
+        brains = self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)
+        self.assertEqual([brain.review_state for brain in brains], ["canceled"])
 
     def test_anon_can_delete_anon_booking(self):
         logout()
@@ -172,10 +174,8 @@ class TestDeleteBookingApi(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(
-            len(self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)),
-            0,
-        )
+        brains = self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)
+        self.assertEqual([brain.review_state for brain in brains], ["canceled"])
 
     def test_user_can_delete_his_booking(self):
         login(self.portal, "user")
@@ -199,10 +199,9 @@ class TestDeleteBookingApi(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(
-            len(self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)),
-            0,
-        )
+        # the booking is marked as canceled
+        brains = self.portal.portal_catalog.unrestrictedSearchResults(UID=uid)
+        self.assertEqual([brain.review_state for brain in brains], ["canceled"])
 
     @unittest.skip("wip")
     def test_user_cant_delete_other_user_booking(self):

--- a/src/redturtle/prenotazioni/upgrades.py
+++ b/src/redturtle/prenotazioni/upgrades.py
@@ -473,6 +473,7 @@ def to_2005(context):
 
 
 def to_2006(context):
+    import pdb; pdb.set_trace()
     context.runImportStepFromProfile(
         "profile-redturtle.prenotazioni:to_2006", "workflow"
     )

--- a/src/redturtle/prenotazioni/upgrades.py
+++ b/src/redturtle/prenotazioni/upgrades.py
@@ -473,7 +473,6 @@ def to_2005(context):
 
 
 def to_2006(context):
-    import pdb; pdb.set_trace()
     context.runImportStepFromProfile(
         "profile-redturtle.prenotazioni:to_2006", "workflow"
     )

--- a/src/redturtle/prenotazioni/upgrades.py
+++ b/src/redturtle/prenotazioni/upgrades.py
@@ -470,3 +470,9 @@ def to_2005(context):
     context.runImportStepFromProfile(
         "profile-redturtle.prenotazioni:to_2005", "rolemap"
     )
+
+
+def to_2006(context):
+    context.runImportStepFromProfile(
+        "profile-redturtle.prenotazioni:to_2006", "workflow"
+    )

--- a/src/redturtle/prenotazioni/upgrades.zcml
+++ b/src/redturtle/prenotazioni/upgrades.zcml
@@ -316,6 +316,15 @@
         handler=".upgrades.to_2005"
         />
   </genericsetup:upgradeSteps>
+
+  <genericsetup:registerProfile
+      name="to_2006"
+      title="redturtle.prenotazioni (to_2006)"
+      description="redturtle.prenotazioni to 2006."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/to_2006"
+      />
+
   <genericsetup:upgradeSteps
       profile="redturtle.prenotazioni:default"
       source="2005"

--- a/src/redturtle/prenotazioni/upgrades.zcml
+++ b/src/redturtle/prenotazioni/upgrades.zcml
@@ -306,4 +306,24 @@
         handler=".upgrades.to_2004"
         />
   </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+      profile="redturtle.prenotazioni:default"
+      source="2004"
+      destination="2005"
+      >
+    <genericsetup:upgradeStep
+        title="Upgrade rolemap"
+        handler=".upgrades.to_2005"
+        />
+  </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+      profile="redturtle.prenotazioni:default"
+      source="2005"
+      destination="2006"
+      >
+    <genericsetup:upgradeStep
+        title="Update booking workflow (canceled state)"
+        handler=".upgrades.to_2006"
+        />
+  </genericsetup:upgradeSteps>
 </configure>


### PR DESCRIPTION
l'azione dell'utente di cancellare una prenotazione ora fa un cambio di stato in "canceled" anzichè eliminare l'oggetto prenotazione