### PR TITLE
Fix Plone site rolemap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix rolemap
+  [lucabel]
 
 
 2.5.1 (2024-03-06)

--- a/src/redturtle/prenotazioni/profiles/default/metadata.xml
+++ b/src/redturtle/prenotazioni/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2006</version>
+  <version>2007</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/redturtle/prenotazioni/profiles/default/rolemap.xml
+++ b/src/redturtle/prenotazioni/profiles/default/rolemap.xml
@@ -93,11 +93,21 @@
                 name="Delete objects"
     >
       <role name="Bookings Manager" />
+      <role name="Editor" />
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Site Administrator" />
     </permission>
     <permission acquire="True"
                 name="CMFEditions: Access previous versions"
     >
       <role name="Bookings Manager" />
+      <role name="Manager" />
+      <role name="Site Administrator" />
+      <role name="Owner" />
+      <role name="Editor" />
+      <role name="Reviewer" />
+      <role name="Contributor" />
     </permission>
 
   </permissions>

--- a/src/redturtle/prenotazioni/upgrades.py
+++ b/src/redturtle/prenotazioni/upgrades.py
@@ -476,3 +476,7 @@ def to_2006(context):
     context.runImportStepFromProfile(
         "profile-redturtle.prenotazioni:to_2006", "workflow"
     )
+
+
+def to_2007(context):
+    update_rolemap(context)

--- a/src/redturtle/prenotazioni/upgrades.zcml
+++ b/src/redturtle/prenotazioni/upgrades.zcml
@@ -335,4 +335,15 @@
         handler=".upgrades.to_2006"
         />
   </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+      profile="redturtle.prenotazioni:default"
+      source="2006"
+      destination="2007"
+      >
+    <genericsetup:upgradeStep
+        title="Update rolemap: restore some plone permission"
+        handler=".upgrades.to_2007"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>


### PR DESCRIPTION
One of the recent updates broke the site's role map by removing deletion permissions from various Plone site roles. The pull request fixes the role map to restore the previous situation.

We noticed this on some portals after a customer request, and saw it's just a permissions issue. Reproduced locally on non-updated sites: if I update redturtle.prenotazioni and apply the last upgrade steps, the permissions role matrix loses values. This pull request restores them