### PR TITLE
Manage the user's phone attribute in booking-schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 2.5.4 (unreleased)
 ------------------
 
+- Manage the user's phone attribute in booking-schema
+  [mamico]
+
 - Return empty data from the @day endpoint if requested date is out of PrenotazioniFolder range
   [folix-01]
 

--- a/src/redturtle/prenotazioni/restapi/services/booking_schema/get.py
+++ b/src/redturtle/prenotazioni/restapi/services/booking_schema/get.py
@@ -96,6 +96,11 @@ class BookingSchema(Service):
                     value = current_user.getProperty("email")
                     # readonly solo se ha un valore
                     is_readonly = bool(value)
+                if field == "phone":
+                    value = current_user.getProperty("phone", "")
+                    # readonly solo se ha un valore (?) non lo lascerei mai readonly permettendo al cittadino
+                    # di modificare il proprio numero di telefono
+                    # is_readonly = bool(value)
                 if field == "fiscalcode":
                     value = current_user.getUserName()
                     is_readonly = True


### PR DESCRIPTION
Se l'utente ha un campo phone, allora viene riportato tra i valori precompilati.

Ho pensato meglio lasciarlo comunque modificabile, perchè chi prenota potrebbe voler dare un altro recapito telefonico o nessuno

In plone serve che il campo "phone" sia tra i campi dell'utente e nelle integrazioni shibboleth/jwt/ldap/... serve che ci sia un mapping tra i dati che arrivano e l'attributo phone