### PR TITLE
Fix day endpoint to show the available scheduling for the same day as…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
+- Fix day endpoint to show the available scheduling for the same day as start date.
+  [folix-01]
+
 - Manage the user's phone attribute in booking-schema
   [mamico]
 

--- a/src/redturtle/prenotazioni/restapi/services/day/day.py
+++ b/src/redturtle/prenotazioni/restapi/services/day/day.py
@@ -114,7 +114,7 @@ class DaySlots(Service):
         }
 
         # check if date is in the Booking Folder availability dates range
-        if self.context.daData < self.day and (
+        if self.context.daData <= self.day and (
             not self.context.aData or self.context.aData >= self.day
         ):
             response.update(


### PR DESCRIPTION
… start date