### PR TITLE
Workarounds for external integration: search with tinit- prefixed user, schema with some fields with only spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 2.6.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Workarounds for esternal integration: search with tinit- prefixed user,
+  schema with some ields with only spaces
+  [mamico]
 
 
 2.6.5 (2024-04-24)

--- a/src/redturtle/prenotazioni/restapi/services/booking_schema/get.py
+++ b/src/redturtle/prenotazioni/restapi/services/booking_schema/get.py
@@ -95,6 +95,8 @@ class BookingSchema(Service):
                 if field == "email":
                     value = current_user.getProperty("email")
                     # readonly solo se ha un valore
+                    if value:
+                        value = value.strip()
                     is_readonly = bool(value)
                 if field == "phone":
                     value = current_user.getProperty("phone", "")
@@ -107,6 +109,8 @@ class BookingSchema(Service):
                 if field == "title":
                     value = current_user.getProperty("fullname")
                     # readonly solo se ha un valore
+                    if value:
+                        value = value.strip()
                     is_readonly = bool(value)
 
             fields_list.append(

--- a/src/redturtle/prenotazioni/restapi/services/bookings/search.py
+++ b/src/redturtle/prenotazioni/restapi/services/bookings/search.py
@@ -44,7 +44,11 @@ class BookingsSearch(Service):
             userid = api.user.get_current().getUserId()
 
         if userid:
-            query["fiscalcode"] = userid.upper()
+            if userid.lower().startswith("tinit-") and userid[6:]:
+                # search for both the original and the prefixed fiscalcode
+                query["fiscalcode"] = [userid.upper(), userid[6:].upper()]
+            else:
+                query["fiscalcode"] = userid.upper()
 
         start_date = self.request.get("from", None)
         end_date = self.request.get("to", None)


### PR DESCRIPTION
Workarounds for external integration: search with tinit- prefixed user, schema with some fields with only spaces