### PR TITLE
Manager validity dates restrictions + Add booking date validation (didn’t exist before)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 2.7.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Apply validity dates restrictions for the Bookings Manger if selected flag 'apply_date_restrictions_to_manager'.
+  [folix-01]
+
+- Fixed missing validity dates check during the booking creation.
+  [folix-01]
 
 
 2.7.9 (2024-10-09)

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -146,7 +146,10 @@ class Booker(object):
         Managers bypass this check
         """
         future_days = booking.getFutureDays()
-        if future_days and not self.prenotazioni.user_can_manage_prenotazioni:
+        if future_days and not (
+            self.prenotazioni.user_can_manage_prenotazioni
+            and not self.prenotazioni.bookins_manager_is_restricted_by_dates
+        ):
             if exceedes_date_limit(data, future_days):
                 msg = _("Sorry, you can not book this slot for now.")
                 raise BookerException(api.portal.translate(msg))

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import math
-from datetime import timedelta, datetime
+from datetime import datetime
+from datetime import timedelta
 from random import choice
 
 from DateTime import DateTime
@@ -144,8 +145,6 @@ class Booker(object):
         Check if date is in the right range.
         Managers bypass this check
         """
-        future_days = booking.getFutureDays()
-
         booking_date = data.get("booking_date", None)
 
         if not isinstance(booking_date, datetime):
@@ -156,12 +155,11 @@ class Booker(object):
             and not self.prenotazioni.bookins_manager_is_restricted_by_dates
         )
 
-        if future_days and not self.prenotazioni.user_can_manage_prenotazioni:
-            if not self.prenotazioni.is_valid_day(
-                booking_date, bypass_user_restrictions=bypass_user_restrictions
-            ):
-                msg = _("Sorry, you can not book this slot for now.")
-                raise BookerException(api.portal.translate(msg))
+        if not self.prenotazioni.is_valid_day(
+            booking_date, bypass_user_restrictions=bypass_user_restrictions
+        ):
+            msg = _("Sorry, you can not book this slot for now.")
+            raise BookerException(api.portal.translate(msg))
 
     def generate_params(self, data, force_gate, duration):
         # remove empty fields

--- a/src/redturtle/prenotazioni/adapters/booker.py
+++ b/src/redturtle/prenotazioni/adapters/booker.py
@@ -30,7 +30,6 @@ from redturtle.prenotazioni.exceptions import BookingsLimitExceded
 from redturtle.prenotazioni.interfaces import IBookingEmailMessage
 from redturtle.prenotazioni.interfaces import IBookingNotificationSender
 from redturtle.prenotazioni.prenotazione_event import MovedPrenotazione
-from redturtle.prenotazioni.utilities.dateutils import exceedes_date_limit
 
 
 class IBooker(Interface):

--- a/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
@@ -296,12 +296,23 @@ class PrenotazioniContextState(BrowserView):
 
     @memoize
     def is_valid_day(self, day, bypass_user_restrictions=False):
-        """Returns True if the day is valid"""
+        """Returns True if the day is valid
+        Day is not valid in those conditions:
+            - day is out of validity range
+                (not applied to BookingManager if PrenotazioniFolder.bookins_manager_is_restricted_by_dates is False)
+            - day is vacation day
+            - day is out of PrenotazioniFolder.futures_day range
+                (not applied to BookingManager if PrenotazioniFolder.bookins_manager_is_restricted_by_dates is False)
+            - week day is not configured
+        """
 
         if isinstance(day, datetime):
             day = day.date()
 
         is_configured_day = self.is_configured_day(day)
+
+        if bypass_user_restrictions:
+            return True
 
         if (
             is_configured_day
@@ -316,20 +327,16 @@ class PrenotazioniContextState(BrowserView):
         if self.is_vacation_day(day):
             return False
 
-        if not bypass_user_restrictions and (
-            self.last_bookable_day and day > self.last_bookable_day
-        ):
+        if self.last_bookable_day and day > self.last_bookable_day:
             return False
 
-        if self.is_before_allowed_period(
-            day, bypass_user_restrictions=bypass_user_restrictions
-        ):
+        if self.is_before_allowed_period(day, bypass_user_restrictions=False):
             return False
 
         if self.future_days_limit:
             date_limit = date.today() + timedelta(days=self.future_days_limit)
 
-            if day >= date_limit and not bypass_user_restrictions:
+            if day >= date_limit:
                 return False
 
         return is_configured_day

--- a/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
@@ -95,6 +95,12 @@ class PrenotazioniContextState(BrowserView):
 
     @property
     @memoize
+    def bookins_manager_is_restricted_by_dates(self):
+        """Bookings manager is restricted by dates as an usual user"""
+        return self.context.apply_date_restrictions_to_manager
+
+    @property
+    @memoize
     def booker(self):
         """
         Return the conflict manager for this context

--- a/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
+++ b/src/redturtle/prenotazioni/browser/prenotazioni_context_state.py
@@ -326,10 +326,11 @@ class PrenotazioniContextState(BrowserView):
         ):
             return False
 
-        date_limit = date.today() + timedelta(days=self.future_days_limit)
+        if self.future_days_limit:
+            date_limit = date.today() + timedelta(days=self.future_days_limit)
 
-        if day >= date_limit and not bypass_user_restrictions:
-            return False
+            if day >= date_limit and not bypass_user_restrictions:
+                return False
 
         return is_configured_day
 

--- a/src/redturtle/prenotazioni/content/prenotazioni_folder.py
+++ b/src/redturtle/prenotazioni/content/prenotazioni_folder.py
@@ -374,7 +374,7 @@ class IPrenotazioniFolder(model.Schema):
     )
 
     notBeforeDays = schema.Int(
-        default=2,
+        default=0,
         title=_("Days booking is not allowed before"),
         description=_(
             "notBeforeDays",

--- a/src/redturtle/prenotazioni/content/prenotazioni_folder.py
+++ b/src/redturtle/prenotazioni/content/prenotazioni_folder.py
@@ -212,6 +212,17 @@ class IPrenotazioniFolder(model.Schema):
         required=False,
     )
 
+    apply_date_restrictions_to_manager = schema.Bool(
+        title=_(
+            "Apply restrictions to Bookings Manager",
+        ),
+        description=_(
+            "If selected, Bookings Manager will be restricted by selected dates as an usual user."
+        ),
+        required=False,
+        default=False,
+    )
+
     def get_options():
         """Return the options for this widget"""
         options = [
@@ -512,6 +523,7 @@ class IPrenotazioniFolder(model.Schema):
             "holidays",
             "futureDays",
             "notBeforeDays",
+            "apply_date_restrictions_to_manager",
         ],
     )
 

--- a/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/en/LC_MESSAGES/redturtle.prenotazioni.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-09-13 14:01+0000\n"
+"POT-Creation-Date: 2024-08-19 10:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,14 +31,13 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:213
-#: redturtle/prenotazioni/restapi/services/booking/update.py:73
-msgid "Additional field '${additional_field_name}' value is required."
-msgstr ""
-
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:433
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:444
 #: redturtle/prenotazioni/content/validators.py:222
 msgid "Afternoon start should not be greater than end."
+msgstr ""
+
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:216
+msgid "Apply restrictions to Bookings Manager"
 msgstr ""
 
 #: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
@@ -140,11 +139,11 @@ msgstr ""
 msgid "Data inizio validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:507
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:518
 msgid "Date validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
 msgid "Days booking is not allowed before"
 msgstr ""
 
@@ -192,6 +191,10 @@ msgstr ""
 msgid "How to get here"
 msgstr ""
 
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:219
+msgid "If selected, Bookings Manager will be restricted by selected dates as an usual user."
+msgstr ""
+
 #: redturtle/prenotazioni/content/validators.py:93
 msgid "In the same day there are overlapping intervals"
 msgstr ""
@@ -204,7 +207,7 @@ msgstr ""
 msgid "Inserire il testo di presentazione dell'agenda corrente"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:405
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:416
 msgid "Insert a list of email addresses that will be notified when new bookings get created."
 msgstr ""
 
@@ -232,11 +235,11 @@ msgstr ""
 msgid "Insert here the contact phone"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:317
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:328
 msgid "Insert pause table schema."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:240
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:251
 msgid "Insert week table schema."
 msgstr ""
 
@@ -248,7 +251,7 @@ msgstr ""
 msgid "Installs the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:355
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:366
 msgid "Max days in the future"
 msgstr ""
 
@@ -256,7 +259,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:430
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:441
 #: redturtle/prenotazioni/content/validators.py:217
 msgid "Morning start should not be greater than end."
 msgstr ""
@@ -275,7 +278,7 @@ msgstr ""
 msgid "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:219
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:230
 msgid "No"
 msgstr ""
 
@@ -307,7 +310,7 @@ msgstr ""
 msgid "Pause should be included in morning slot or afternoon slot"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:316
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:327
 msgid "Pause table"
 msgstr ""
 
@@ -343,7 +346,7 @@ msgstr ""
 msgid "Required input is missing."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:404
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:415
 msgid "Responsible email"
 msgstr ""
 
@@ -359,16 +362,16 @@ msgstr ""
 msgid "Select a day"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:301
-#: redturtle/prenotazioni/restapi/services/booking/add.py:66
+#: redturtle/prenotazioni/adapters/booker.py:310
+#: redturtle/prenotazioni/restapi/services/booking/add.py:63
 msgid "Sorry, this slot is not available anymore."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:344
+#: redturtle/prenotazioni/adapters/booker.py:353
 msgid "Sorry, this slot is not available or does not fit your booking."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:151
+#: redturtle/prenotazioni/adapters/booker.py:162
 msgid "Sorry, you can not book this slot for now."
 msgstr ""
 
@@ -464,11 +467,11 @@ msgstr ""
 msgid "The phone number of the user who made the reservation."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:393
+#: redturtle/prenotazioni/adapters/booker.py:402
 msgid "This day is not valid."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:388
+#: redturtle/prenotazioni/adapters/booker.py:397
 msgid "This gate has some booking schedule in this time period."
 msgstr ""
 
@@ -511,11 +514,11 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:239
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:250
 msgid "Week table"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:218
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:229
 msgid "Yes"
 msgstr ""
 
@@ -527,22 +530,22 @@ msgstr ""
 msgid "You must set both start and end"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:427
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:438
 #: redturtle/prenotazioni/content/validators.py:212
 msgid "You should set a start time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:423
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:434
 #: redturtle/prenotazioni/content/validators.py:204
 msgid "You should set a start time for morning."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:425
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
 #: redturtle/prenotazioni/content/validators.py:208
 msgid "You should set an end time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:421
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:432
 #: redturtle/prenotazioni/content/validators.py:200
 msgid "You should set an end time for morning."
 msgstr ""
@@ -595,22 +598,22 @@ msgid "all"
 msgstr ""
 
 #. Default: "Automatically confirm."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:385
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:396
 msgid "auto_confirm"
 msgstr ""
 
 #. Default: "All bookings will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:386
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:397
 msgid "auto_confirm_help"
 msgstr ""
 
 #. Default: "Automatically confirmfor managers."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:394
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:405
 msgid "auto_confirm_manager"
 msgstr ""
 
 #. Default: "All bookings created by Managers will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:395
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:406
 msgid "auto_confirm_manager_help"
 msgstr ""
 
@@ -665,7 +668,7 @@ msgid "booking_details_help_text_label_help"
 msgstr ""
 
 #. Default: "Booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:536
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:548
 msgid "booking_fields_label"
 msgstr ""
 
@@ -965,17 +968,17 @@ msgid "fullname"
 msgstr ""
 
 #. Default: "Limit booking in the future to an amount of days in the future starting from the current day. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:356
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
 msgid "futureDays"
 msgstr ""
 
 #. Default: "Put gates here (one per line)."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:389
 msgid "gates_help"
 msgstr ""
 
 #. Default: "Gates"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:377
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:388
 msgid "gates_label"
 msgstr ""
 
@@ -989,7 +992,7 @@ msgid "help_required_booking_fields"
 msgstr ""
 
 #. Default: "States if it is not allowed to reserve a booking during the current day"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:229
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:240
 msgid "help_same_day_booking_disallowed"
 msgstr ""
 
@@ -1059,12 +1062,12 @@ msgid "history_sms_transition_sent"
 msgstr ""
 
 #. Default: "Set holidays (one for line) in DD/MM/YYYY. you can write * for the year, if this event is yearly."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:330
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:341
 msgid "holidays_help"
 msgstr ""
 
 #. Default: "Holidays"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:329
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:340
 msgid "holidays_label"
 msgstr ""
 
@@ -1223,7 +1226,7 @@ msgid "label_required_booking_fields"
 msgstr ""
 
 #. Default: "Disallow same day booking"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:225
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:236
 msgid "label_same_day_booking_disallowed"
 msgstr ""
 
@@ -1285,12 +1288,12 @@ msgid "legend_note"
 msgstr ""
 
 #. Default: "The number of simultaneous bookings allowed for the same user."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:485
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:496
 msgid "max_bookings_allowed_description"
 msgstr ""
 
 #. Default: "Maximum bookings number allowed"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:481
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:492
 msgid "max_bookings_allowed_label"
 msgstr ""
 
@@ -1340,7 +1343,7 @@ msgid "next-week"
 msgstr ""
 
 #. Default: "Booking is not allowed before the amount of days specified. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:368
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:379
 msgid "notBeforeDays"
 msgstr ""
 
@@ -1365,7 +1368,7 @@ msgid "notifications_email_enabled_label"
 msgstr ""
 
 #. Default: "Notifications"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:544
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:556
 msgid "notifications_label"
 msgstr ""
 
@@ -1435,7 +1438,7 @@ msgid "notify_as_reminder_subject_help"
 msgstr ""
 
 #. Default: "Notify when canceled."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:472
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:483
 msgid "notify_on_cancel"
 msgstr ""
 
@@ -1450,7 +1453,7 @@ msgid "notify_on_cancel_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been canceled."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:473
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:484
 msgid "notify_on_cancel_help"
 msgstr ""
 
@@ -1496,7 +1499,7 @@ msgid "notify_on_cancel_subject_help"
 msgstr ""
 
 #. Default: "Notify when confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:445
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:456
 msgid "notify_on_confirm"
 msgstr ""
 
@@ -1511,7 +1514,7 @@ msgid "notify_on_confirm_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:446
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:457
 msgid "notify_on_confirm_help"
 msgstr ""
 
@@ -1557,7 +1560,7 @@ msgid "notify_on_confirm_subject_help"
 msgstr ""
 
 #. Default: "Notify when moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:454
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:465
 msgid "notify_on_move"
 msgstr ""
 
@@ -1572,7 +1575,7 @@ msgid "notify_on_move_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:455
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:466
 msgid "notify_on_move_help"
 msgstr ""
 
@@ -1618,7 +1621,7 @@ msgid "notify_on_move_subject_help"
 msgstr ""
 
 #. Default: "Notify when rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:463
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:474
 msgid "notify_on_refuse"
 msgstr ""
 
@@ -1633,7 +1636,7 @@ msgid "notify_on_refuse_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:464
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:475
 msgid "notify_on_refuse_help"
 msgstr ""
 
@@ -1679,7 +1682,7 @@ msgid "notify_on_refuse_subject_help"
 msgstr ""
 
 #. Default: "Notify when created."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:447
 msgid "notify_on_submit"
 msgstr ""
 
@@ -1694,7 +1697,7 @@ msgid "notify_on_submit_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been created. If auto-confirm flag is selected and confirm notify is selected, this one will be ignored."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:437
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:448
 msgid "notify_on_submit_help"
 msgstr ""
 
@@ -1821,12 +1824,12 @@ msgid "reject_booking"
 msgstr ""
 
 #. Default: "Set how many days before of a booking date the user will be notified about it."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:497
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:508
 msgid "reminder_notification_gap_description"
 msgstr ""
 
 #. Default: "Booking reminder days"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:493
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:504
 msgid "reminder_notification_gap_label"
 msgstr ""
 
@@ -1935,12 +1938,12 @@ msgid "view_booking"
 msgstr ""
 
 #. Default: "Insert here week schema for some custom date intervals."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:307
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:318
 msgid "week_table_overrides_help"
 msgstr ""
 
 #. Default: "Week table overrides"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:306
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:317
 msgid "week_table_overrides_label"
 msgstr ""
 

--- a/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
+++ b/src/redturtle/prenotazioni/locales/it/LC_MESSAGES/redturtle.prenotazioni.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-09-13 14:01+0000\n"
+"POT-Creation-Date: 2024-08-19 10:07+0000\n"
 "PO-Revision-Date: 2014-05-27 17:36+0200\n"
 "Last-Translator: Alessandro Pisa <alessandro.pisa@redturtle.it>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -33,15 +33,14 @@ msgstr "Una cartella che conterrà le prenotazioni per questo day"
 msgid "Add"
 msgstr "Aggiungi"
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:213
-#: redturtle/prenotazioni/restapi/services/booking/update.py:73
-msgid "Additional field '${additional_field_name}' value is required."
-msgstr "Campo aggiuntivo '${additional_field_name}' è obbligatorio."
-
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:433
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:444
 #: redturtle/prenotazioni/content/validators.py:222
 msgid "Afternoon start should not be greater than end."
 msgstr "L'orario di inizio del pomeriggio non può essere successivo alla chiusura."
+
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:216
+msgid "Apply restrictions to Bookings Manager"
+msgstr "Applica le restrizioni al Gestore Prenotazioni."
 
 #: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
 msgid "Attention"
@@ -142,11 +141,11 @@ msgstr "Data fine validità"
 msgid "Data inizio validità"
 msgstr "Data inizio validità"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:507
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:518
 msgid "Date validità"
 msgstr "Date Validità"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
 msgid "Days booking is not allowed before"
 msgstr "Giorni da cui si può effettuare una prenotazione"
 
@@ -194,6 +193,10 @@ msgstr "Gruppo"
 msgid "How to get here"
 msgstr "Indicazioni su come raggiungere l'ufficio"
 
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:219
+msgid "If selected, Bookings Manager will be restricted by selected dates as an usual user."
+msgstr "Se selezionato, il gestore prenotazioni sarà ristretto dalle date di validita della stanza."
+
 #: redturtle/prenotazioni/content/validators.py:93
 msgid "In the same day there are overlapping intervals"
 msgstr "Ci sono pause che si sovrappongono nello stesso giorno"
@@ -206,7 +209,7 @@ msgstr "Informazioni relativa ad una singola prenotazione"
 msgid "Inserire il testo di presentazione dell'agenda corrente"
 msgstr "Inserire il testo di presentazione dell'agenda corrente"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:405
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:416
 msgid "Insert a list of email addresses that will be notified when new bookings get created."
 msgstr "Inserisci una lista di indirizzi email che verranno notificati alla creazione di una nuova prenotazione."
 
@@ -234,11 +237,11 @@ msgstr "Inserire il numero di FAX per per contattare l'ufficio"
 msgid "Insert here the contact phone"
 msgstr "Inserire il numero di telefono per contattare l'ufficio"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:317
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:328
 msgid "Insert pause table schema."
 msgstr "Inserisci le pause giornaliere. Esistono tre tipi di vincolo: una data di termine pausa deve essere maggiore della data di inizio pausa; le pause nello stesso giorno non possono sovrapporsi; le pause devono essere comprese fra l'inizio e la fine dell'orario di lavoro."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:240
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:251
 msgid "Insert week table schema."
 msgstr "Compila la tabella degli orari della settimana."
 
@@ -250,7 +253,7 @@ msgstr "Install redturtle.prenotazioni"
 msgid "Installs the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr "Installa il profilo redturtle.prenotazioni.demo."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:355
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:366
 msgid "Max days in the future"
 msgstr "Massimi giorni nel futuro"
 
@@ -258,7 +261,7 @@ msgstr "Massimi giorni nel futuro"
 msgid "Monday"
 msgstr "Lunedì"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:430
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:441
 #: redturtle/prenotazioni/content/validators.py:217
 msgid "Morning start should not be greater than end."
 msgstr "L'orario di inizio della mattina non può essere successivo alla fine."
@@ -277,7 +280,7 @@ msgstr "Sposta in su"
 msgid "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 msgstr "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:219
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:230
 msgid "No"
 msgstr "No"
 
@@ -309,7 +312,7 @@ msgstr "Il termine della pausa non può avvenire prima del suo inizio"
 msgid "Pause should be included in morning slot or afternoon slot"
 msgstr "Le pause devono essere comprese tra l'orario di inizio o di termine dell'intervallo di orari di lavoro"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:316
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:327
 msgid "Pause table"
 msgstr "Schedulazione delle pause"
 
@@ -345,7 +348,7 @@ msgstr "Campo obbligatorio '${field}' mancante."
 msgid "Required input is missing."
 msgstr "Manca l'input obbligatorio."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:404
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:415
 msgid "Responsible email"
 msgstr "Email del responsabile"
 
@@ -361,16 +364,16 @@ msgstr "Parametri di ricerca"
 msgid "Select a day"
 msgstr "Seleziona un giorno"
 
-#: redturtle/prenotazioni/adapters/booker.py:301
-#: redturtle/prenotazioni/restapi/services/booking/add.py:66
+#: redturtle/prenotazioni/adapters/booker.py:310
+#: redturtle/prenotazioni/restapi/services/booking/add.py:63
 msgid "Sorry, this slot is not available anymore."
 msgstr "Ci dispiace, ma questo intervallo di tempo non è più disponibile"
 
-#: redturtle/prenotazioni/adapters/booker.py:344
+#: redturtle/prenotazioni/adapters/booker.py:353
 msgid "Sorry, this slot is not available or does not fit your booking."
 msgstr "Ci dispiace questo intervallo di tempo non è disponibile o non è adatto alla tua prenotazione."
 
-#: redturtle/prenotazioni/adapters/booker.py:151
+#: redturtle/prenotazioni/adapters/booker.py:162
 msgid "Sorry, you can not book this slot for now."
 msgstr "Ci dispiace, ma questo intervallo di tempo non è al momento disponibile"
 
@@ -466,11 +469,11 @@ msgstr "Le informazioni per raggiungere l'ufficio presso cui si prenota"
 msgid "The phone number of the user who made the reservation."
 msgstr "Il numero di telefono di chi ha prenotato"
 
-#: redturtle/prenotazioni/adapters/booker.py:393
+#: redturtle/prenotazioni/adapters/booker.py:402
 msgid "This day is not valid."
 msgstr "Il giorno inserito non è valido."
 
-#: redturtle/prenotazioni/adapters/booker.py:388
+#: redturtle/prenotazioni/adapters/booker.py:397
 msgid "This gate has some booking schedule in this time period."
 msgstr "Lo sportello selezionato ha già delle prenotazioni nel periodo indicato."
 
@@ -513,11 +516,11 @@ msgstr "Vista"
 msgid "Wednesday"
 msgstr "Mercoledì"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:239
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:250
 msgid "Week table"
 msgstr "Schedulazione Settimanale"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:218
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:229
 msgid "Yes"
 msgstr "Si"
 
@@ -529,22 +532,22 @@ msgstr "Non hai i permessi necessari a forzare lo sportello."
 msgid "You must set both start and end"
 msgstr "Devi impostare sia un orario di inizio che di termine della pausa"
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:427
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:438
 #: redturtle/prenotazioni/content/validators.py:212
 msgid "You should set a start time for afternoon."
 msgstr "Devi impostare una data di inizio per il pomeriggio."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:423
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:434
 #: redturtle/prenotazioni/content/validators.py:204
 msgid "You should set a start time for morning."
 msgstr "Devi impostare una data di inizio per la mattina."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:425
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
 #: redturtle/prenotazioni/content/validators.py:208
 msgid "You should set an end time for afternoon."
 msgstr "Devi impostare una data di fine per il pomeriggio."
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:421
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:432
 #: redturtle/prenotazioni/content/validators.py:200
 msgid "You should set an end time for morning."
 msgstr "Devi impostare una data di fine per la mattina."
@@ -597,22 +600,22 @@ msgid "all"
 msgstr "Tutti"
 
 #. Default: "Automatically confirm."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:385
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:396
 msgid "auto_confirm"
 msgstr "Conferma automatica delle prenotazioni"
 
 #. Default: "All bookings will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:386
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:397
 msgid "auto_confirm_help"
 msgstr "Tutte le prenotazioni verranno accettate automaticamente"
 
 #. Default: "Automatically confirmfor managers."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:394
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:405
 msgid "auto_confirm_manager"
 msgstr "Conferma automatica delle prenotazioni dei Gestori"
 
 #. Default: "All bookings created by Managers will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:395
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:406
 msgid "auto_confirm_manager_help"
 msgstr "Tutte le prenotazioni create dai Gestori verranno accettate automaticamente."
 
@@ -708,7 +711,7 @@ msgid "booking_details_help_text_label_help"
 msgstr "Il testo verra visualizzato come testo d'aiuto per la compilazione del campo \"Dettagli\" da parte del cittadino nella form della prenotazione"
 
 #. Default: "Booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:536
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:548
 msgid "booking_fields_label"
 msgstr "Campi Prenotazioni"
 
@@ -1008,17 +1011,17 @@ msgid "fullname"
 msgstr "Nome completo"
 
 #. Default: "Limit booking in the future to an amount of days in the future starting from the current day. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:356
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
 msgid "futureDays"
 msgstr "Limita la prenotazione ad un certo numero di giorni nel futuro partendo dal day corrente.Lascia 0 per non dare limiti."
 
 #. Default: "Put gates here (one per line)."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:389
 msgid "gates_help"
 msgstr "Inserisci le postazioni preposte (uno per riga)."
 
 #. Default: "Gates"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:377
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:388
 msgid "gates_label"
 msgstr "Postazioni preposte"
 
@@ -1032,7 +1035,7 @@ msgid "help_required_booking_fields"
 msgstr "Gli utenti non saranno in grado di creare una prenotazione senza compilare i seguenti campi. Gli utenti saranno comunque sempre obbligati ad inserire un'email o un recapito telefonico."
 
 #. Default: "States if it is not allowed to reserve a booking during the current day"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:229
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:240
 msgid "help_same_day_booking_disallowed"
 msgstr "Se selezionato, impedisce agli utenti di prenotare per il giorno corrente."
 
@@ -1102,12 +1105,12 @@ msgid "history_sms_transition_sent"
 msgstr "Inviata notifica SMS per il cambio di stato della prenotazione: ${transition}"
 
 #. Default: "Set holidays (one for line) in DD/MM/YYYY. you can write * for the year, if this event is yearly."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:330
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:341
 msgid "holidays_help"
 msgstr "Imposta eventuali festività (una per riga) nel formato GG/MM/AAAA. Se la data si ripete ogni anno, puoi scrivere * al posto dell'anno."
 
 #. Default: "Holidays"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:329
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:340
 msgid "holidays_label"
 msgstr "Festività"
 
@@ -1273,7 +1276,7 @@ msgid "label_required_booking_fields"
 msgstr "Campi obbligatori"
 
 #. Default: "Disallow same day booking"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:225
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:236
 msgid "label_same_day_booking_disallowed"
 msgstr "Disabilita la prenotazione per lo stesso giorno"
 
@@ -1335,12 +1338,12 @@ msgid "legend_note"
 msgstr "L'unità di tempo minima è 5 minuti. La tua prenotazione non può eccedere il tempo disponibile."
 
 #. Default: "The number of simultaneous bookings allowed for the same user."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:485
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:496
 msgid "max_bookings_allowed_description"
 msgstr "Numero massimo delle prenotazioni contemporanee per una stessa tipologia, per lo stesso utente. Impostare '0' o lasciare vuoto per non porre limitazioni. Per attivare questo controllo è necessario richiedere obbligatoriamente all'utente il campo 'codice fiscale'"
 
 #. Default: "Maximum bookings number allowed"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:481
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:492
 msgid "max_bookings_allowed_label"
 msgstr "Numero massimo delle prenotazioni"
 
@@ -1390,7 +1393,7 @@ msgid "next-week"
 msgstr "Settimana successiva"
 
 #. Default: "Booking is not allowed before the amount of days specified. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:368
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:379
 msgid "notBeforeDays"
 msgstr "La prenotazione non e' permessa prima del numero di giorni specificata. Impostare il valore 0 per non imporre limitazioni."
 
@@ -1415,7 +1418,7 @@ msgid "notifications_email_enabled_label"
 msgstr "Notifiche Email"
 
 #. Default: "Notifications"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:544
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:556
 msgid "notifications_label"
 msgstr "Gestione delle Notifiche"
 
@@ -1487,7 +1490,7 @@ msgid "notify_as_reminder_subject_help"
 msgstr "L'oggetto del messaggio inviato come promemoria."
 
 #. Default: "Notify when canceled."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:472
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:483
 msgid "notify_on_cancel"
 msgstr "Notifica alla cancellazione"
 
@@ -1502,7 +1505,7 @@ msgid "notify_on_cancel_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione cancellata per ${title}"
 
 #. Default: "Notify via mail the user when his booking has been canceled."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:473
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:484
 msgid "notify_on_cancel_help"
 msgstr "Notifica l'utente via mail se la prenotazione viene cancellata"
 
@@ -1548,7 +1551,7 @@ msgid "notify_on_cancel_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata cancellata."
 
 #. Default: "Notify when confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:445
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:456
 msgid "notify_on_confirm"
 msgstr "Notifica alla conferma"
 
@@ -1565,7 +1568,7 @@ msgid "notify_on_confirm_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione del ${booking_date} alle ${booking_time} accettata"
 
 #. Default: "Notify via mail the user when his booking has been confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:446
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:457
 msgid "notify_on_confirm_help"
 msgstr "Notifica l'utente quando la prenotazione viene confermata."
 
@@ -1613,7 +1616,7 @@ msgid "notify_on_confirm_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata confermata."
 
 #. Default: "Notify when moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:454
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:465
 msgid "notify_on_move"
 msgstr "Notifica allo spostamento"
 
@@ -1631,7 +1634,7 @@ msgid "notify_on_move_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Data di prenotazione modificata per ${title}"
 
 #. Default: "Notify via mail the user when his booking has been moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:455
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:466
 msgid "notify_on_move_help"
 msgstr "Notifica l'utente quando la prenotazione viene spostata di giorno/orario."
 
@@ -1679,7 +1682,7 @@ msgid "notify_on_move_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata spostata."
 
 #. Default: "Notify when rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:463
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:474
 msgid "notify_on_refuse"
 msgstr "Notifica al rifiuto"
 
@@ -1694,7 +1697,7 @@ msgid "notify_on_refuse_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione rifiutata per ${title}"
 
 #. Default: "Notify via mail the user when his booking has been rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:464
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:475
 msgid "notify_on_refuse_help"
 msgstr "Notifica l'utente via mail se la prenotazione viene rifiutata"
 
@@ -1742,7 +1745,7 @@ msgid "notify_on_refuse_subject_help"
 msgstr "L'oggetto del messaggio quando una prenotazione è stata rifiutata."
 
 #. Default: "Notify when created."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:447
 msgid "notify_on_submit"
 msgstr "Notifica alla creazione"
 
@@ -1759,7 +1762,7 @@ msgid "notify_on_submit_appio_subject_default_value"
 msgstr "[${prenotazioni_folder_title}] Prenotazione creata"
 
 #. Default: "Notify via mail the user when his booking has been created. If auto-confirm flag is selected and confirm notify is selected, this one will be ignored."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:437
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:448
 msgid "notify_on_submit_help"
 msgstr "Notifica l'utente quando la prenotazione viene creata. Se il flag di conferma automatica e di notifica alla conferma sono selezionati, questa opzione verrà ignorata."
 
@@ -1886,12 +1889,12 @@ msgid "reject_booking"
 msgstr "Rifiuta la prenotazione"
 
 #. Default: "Set how many days before of a booking date the user will be notified about it."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:497
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:508
 msgid "reminder_notification_gap_description"
 msgstr "Indicare quanti giorni prima della data di prenotazione, inviare un promemoria agli utenti."
 
 #. Default: "Booking reminder days"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:493
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:504
 msgid "reminder_notification_gap_label"
 msgstr "Promemoria prenotazione"
 
@@ -2000,12 +2003,12 @@ msgid "view_booking"
 msgstr "Vedi la prenotazione"
 
 #. Default: "Insert here week schema for some custom date intervals."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:307
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:318
 msgid "week_table_overrides_help"
 msgstr "Inserisci qui eventuali personalizzazioni nella schedulazione settimanale che andranno a vincere su quella standard per un determinato periodo di tempo."
 
 #. Default: "Week table overrides"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:306
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:317
 msgid "week_table_overrides_label"
 msgstr "Personalizzazioni Schedulazione Settimanale"
 

--- a/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
+++ b/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
@@ -201,7 +201,7 @@ msgstr ""
 
 #: redturtle/prenotazioni/content/prenotazioni_folder.py:219
 msgid "If selected, Bookings Manager will be restricted by selected dates as an usual user."
-msgstr ""
+msgstr "Se selezionato, gli operatori avranno le stesse restrizioni sulle date come un qualsiasi utente"
 
 #: redturtle/prenotazioni/content/validators.py:93
 msgid "In the same day there are overlapping intervals"

--- a/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
+++ b/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-09-13 14:01+0000\n"
+"POT-Creation-Date: 2024-08-19 10:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,9 +34,18 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:433
+#: redturtle/prenotazioni/restapi/services/booking/add.py:213
+#: redturtle/prenotazioni/restapi/services/booking/update.py:73
+msgid "Additional field '${additional_field_name}' value is required."
+msgstr ""
+
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:444
 #: redturtle/prenotazioni/content/validators.py:222
 msgid "Afternoon start should not be greater than end."
+msgstr ""
+
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:216
+msgid "Apply restrictions to Bookings Manager"
 msgstr ""
 
 #: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
@@ -125,6 +134,11 @@ msgstr ""
 msgid "Could not send {gateway_type} message due to internal errors"
 msgstr ""
 
+#: redturtle/prenotazioni/restapi/services/booking/add.py:230
+#: redturtle/prenotazioni/restapi/services/booking/update.py:90
+msgid "Could not validate value for the ${field_name} due to: ${err_message}"
+msgstr ""
+
 #: redturtle/prenotazioni/content/prenotazioni_folder.py:207
 msgid "Data fine validità"
 msgstr ""
@@ -133,11 +147,11 @@ msgstr ""
 msgid "Data inizio validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:507
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:518
 msgid "Date validità"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
 msgid "Days booking is not allowed before"
 msgstr ""
 
@@ -185,6 +199,10 @@ msgstr ""
 msgid "How to get here"
 msgstr ""
 
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:219
+msgid "If selected, Bookings Manager will be restricted by selected dates as an usual user."
+msgstr ""
+
 #: redturtle/prenotazioni/content/validators.py:93
 msgid "In the same day there are overlapping intervals"
 msgstr ""
@@ -197,7 +215,7 @@ msgstr ""
 msgid "Inserire il testo di presentazione dell'agenda corrente"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:405
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:416
 msgid "Insert a list of email addresses that will be notified when new bookings get created."
 msgstr ""
 
@@ -225,11 +243,11 @@ msgstr ""
 msgid "Insert here the contact phone"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:317
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:328
 msgid "Insert pause table schema."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:240
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:251
 msgid "Insert week table schema."
 msgstr ""
 
@@ -241,7 +259,7 @@ msgstr ""
 msgid "Installs the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:355
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:366
 msgid "Max days in the future"
 msgstr ""
 
@@ -249,7 +267,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:430
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:441
 #: redturtle/prenotazioni/content/validators.py:217
 msgid "Morning start should not be greater than end."
 msgstr ""
@@ -268,7 +286,7 @@ msgstr ""
 msgid "Nessuno slot creato, verificare la corretteza dei dati inseriti"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:219
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:230
 msgid "No"
 msgstr ""
 
@@ -300,7 +318,7 @@ msgstr ""
 msgid "Pause should be included in morning slot or afternoon slot"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:316
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:327
 msgid "Pause table"
 msgstr ""
 
@@ -328,7 +346,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:120
+#: redturtle/prenotazioni/restapi/services/booking/add.py:123
 msgid "Required input '${field}' is missing."
 msgstr ""
 
@@ -336,7 +354,7 @@ msgstr ""
 msgid "Required input is missing."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:404
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:415
 msgid "Responsible email"
 msgstr ""
 
@@ -352,16 +370,16 @@ msgstr ""
 msgid "Select a day"
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:299
+#: redturtle/prenotazioni/adapters/booker.py:310
 #: redturtle/prenotazioni/restapi/services/booking/add.py:63
 msgid "Sorry, this slot is not available anymore."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:342
+#: redturtle/prenotazioni/adapters/booker.py:353
 msgid "Sorry, this slot is not available or does not fit your booking."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:151
+#: redturtle/prenotazioni/adapters/booker.py:162
 msgid "Sorry, you can not book this slot for now."
 msgstr ""
 
@@ -457,11 +475,11 @@ msgstr ""
 msgid "The phone number of the user who made the reservation."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:391
+#: redturtle/prenotazioni/adapters/booker.py:402
 msgid "This day is not valid."
 msgstr ""
 
-#: redturtle/prenotazioni/adapters/booker.py:386
+#: redturtle/prenotazioni/adapters/booker.py:397
 msgid "This gate has some booking schedule in this time period."
 msgstr ""
 
@@ -481,7 +499,12 @@ msgstr ""
 msgid "Uninstalls the redturtle.prenotazioni.demo add-on (demo site purpose only)."
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:156
+#: redturtle/prenotazioni/restapi/services/booking/add.py:200
+#: redturtle/prenotazioni/restapi/services/booking/update.py:56
+msgid "Unknown additional field '${additional_field_name}'."
+msgstr ""
+
+#: redturtle/prenotazioni/restapi/services/booking/add.py:159
 msgid "Unknown booking type '${booking_type}'."
 msgstr ""
 
@@ -499,15 +522,15 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:239
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:250
 msgid "Week table"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:218
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:229
 msgid "Yes"
 msgstr ""
 
-#: redturtle/prenotazioni/restapi/services/booking/add.py:113
+#: redturtle/prenotazioni/restapi/services/booking/add.py:116
 msgid "You are not allowed to force the gate."
 msgstr ""
 
@@ -515,22 +538,22 @@ msgstr ""
 msgid "You must set both start and end"
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:427
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:438
 #: redturtle/prenotazioni/content/validators.py:212
 msgid "You should set a start time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:423
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:434
 #: redturtle/prenotazioni/content/validators.py:204
 msgid "You should set a start time for morning."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:425
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
 #: redturtle/prenotazioni/content/validators.py:208
 msgid "You should set an end time for afternoon."
 msgstr ""
 
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:421
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:432
 #: redturtle/prenotazioni/content/validators.py:200
 msgid "You should set an end time for morning."
 msgstr ""
@@ -583,22 +606,22 @@ msgid "all"
 msgstr ""
 
 #. Default: "Automatically confirm."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:385
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:396
 msgid "auto_confirm"
 msgstr ""
 
 #. Default: "All bookings will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:386
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:397
 msgid "auto_confirm_help"
 msgstr ""
 
 #. Default: "Automatically confirmfor managers."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:394
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:405
 msgid "auto_confirm_manager"
 msgstr ""
 
 #. Default: "All bookings created by Managers will be automatically accepted."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:395
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:406
 msgid "auto_confirm_manager_help"
 msgstr ""
 
@@ -622,46 +645,6 @@ msgstr ""
 msgid "booked_prenotation_message"
 msgstr ""
 
-#. Default: "Descrizione"
-#: redturtle/prenotazioni/content/prenotazione_type.py:32
-msgid "booking_additional_field_description"
-msgstr ""
-
-#. Default: "Label"
-#: redturtle/prenotazioni/content/prenotazione_type.py:27
-msgid "booking_additional_field_label"
-msgstr ""
-
-#. Default: "id"
-#: redturtle/prenotazioni/content/prenotazione_type.py:18
-msgid "booking_additional_field_name"
-msgstr ""
-
-#. Default: "Additional field id must be unique"
-#: redturtle/prenotazioni/content/prenotazione_type.py:21
-msgid "booking_additional_field_name_help"
-msgstr ""
-
-#. Default: "Required"
-#: redturtle/prenotazioni/content/prenotazione_type.py:42
-msgid "booking_additional_field_required"
-msgstr ""
-
-#. Default: "Tipo"
-#: redturtle/prenotazioni/content/prenotazione_type.py:37
-msgid "booking_additional_field_type"
-msgstr ""
-
-#. Default: "This schema is being used for the additional bookign fields"
-#: redturtle/prenotazioni/content/prenotazione_type.py:79
-msgid "booking_additional_fields_schema_description"
-msgstr ""
-
-#. Default: "Booking additional fields schema"
-#: redturtle/prenotazioni/content/prenotazione_type.py:73
-msgid "booking_additional_fields_schema_title"
-msgstr ""
-
 #. Default: "Booking canceled: "
 #: redturtle/prenotazioni/behaviors/booking_folder/notifications/email/notification_email_message.py:371
 msgid "booking_canceled_mail_subject_part"
@@ -682,18 +665,8 @@ msgstr ""
 msgid "booking_deleted_success"
 msgstr ""
 
-#. Default: "Bookign detail help text"
-#: redturtle/prenotazioni/content/prenotazione_type.py:65
-msgid "booking_details_help_text_label"
-msgstr ""
-
-#. Default: "This field will be visualized as \"Details\" helptext during the booking steps"
-#: redturtle/prenotazioni/content/prenotazione_type.py:66
-msgid "booking_details_help_text_label_help"
-msgstr ""
-
 #. Default: "Booking fields"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:536
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:548
 msgid "booking_fields_label"
 msgstr ""
 
@@ -712,7 +685,7 @@ msgid "booking_refused"
 msgstr ""
 
 #. Default: "Duration value"
-#: redturtle/prenotazioni/content/prenotazione_type.py:39
+#: redturtle/prenotazioni/content/prenotazione_type.py:15
 msgid "booking_type_duration_label"
 msgstr ""
 
@@ -722,12 +695,12 @@ msgid "booking_type_name"
 msgstr ""
 
 #. Default: "List of requirements to recieve the service"
-#: redturtle/prenotazioni/content/prenotazione_type.py:47
+#: redturtle/prenotazioni/content/prenotazione_type.py:23
 msgid "booking_type_requirements_help"
 msgstr ""
 
 #. Default: "Requirements"
-#: redturtle/prenotazioni/content/prenotazione_type.py:46
+#: redturtle/prenotazioni/content/prenotazione_type.py:22
 msgid "booking_type_requirements_labled"
 msgstr ""
 
@@ -993,17 +966,17 @@ msgid "fullname"
 msgstr ""
 
 #. Default: "Limit booking in the future to an amount of days in the future starting from the current day. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:356
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:367
 msgid "futureDays"
 msgstr ""
 
 #. Default: "Put gates here (one per line)."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:378
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:389
 msgid "gates_help"
 msgstr ""
 
 #. Default: "Gates"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:377
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:388
 msgid "gates_label"
 msgstr ""
 
@@ -1017,7 +990,7 @@ msgid "help_required_booking_fields"
 msgstr ""
 
 #. Default: "States if it is not allowed to reserve a booking during the current day"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:229
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:240
 msgid "help_same_day_booking_disallowed"
 msgstr ""
 
@@ -1087,12 +1060,12 @@ msgid "history_sms_transition_sent"
 msgstr ""
 
 #. Default: "Set holidays (one for line) in DD/MM/YYYY. you can write * for the year, if this event is yearly."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:330
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:341
 msgid "holidays_help"
 msgstr ""
 
 #. Default: "Holidays"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:329
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:340
 msgid "holidays_label"
 msgstr ""
 
@@ -1133,11 +1106,6 @@ msgstr ""
 #. Default: "This date is past"
 #: redturtle/prenotazioni/content/prenotazione.py:37
 msgid "is_not_future_date"
-msgstr ""
-
-#. Default: "Text line"
-#: redturtle/prenotazioni/vocabularies/voc_booking_additional_fiels_types.py:19
-msgid "label_booking_additional_field_textline"
 msgstr ""
 
 #. Default: "Booking code"
@@ -1256,7 +1224,7 @@ msgid "label_required_booking_fields"
 msgstr ""
 
 #. Default: "Disallow same day booking"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:225
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:236
 msgid "label_same_day_booking_disallowed"
 msgstr ""
 
@@ -1318,12 +1286,12 @@ msgid "legend_note"
 msgstr ""
 
 #. Default: "The number of simultaneous bookings allowed for the same user."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:485
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:496
 msgid "max_bookings_allowed_description"
 msgstr ""
 
 #. Default: "Maximum bookings number allowed"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:481
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:492
 msgid "max_bookings_allowed_label"
 msgstr ""
 
@@ -1373,7 +1341,7 @@ msgid "next-week"
 msgstr ""
 
 #. Default: "Booking is not allowed before the amount of days specified. \nKeep 0 to give no limits."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:368
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:379
 msgid "notBeforeDays"
 msgstr ""
 
@@ -1398,7 +1366,7 @@ msgid "notifications_email_enabled_label"
 msgstr ""
 
 #. Default: "Notifications"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:544
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:556
 msgid "notifications_label"
 msgstr ""
 
@@ -1468,7 +1436,7 @@ msgid "notify_as_reminder_subject_help"
 msgstr ""
 
 #. Default: "Notify when canceled."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:472
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:483
 msgid "notify_on_cancel"
 msgstr ""
 
@@ -1483,7 +1451,7 @@ msgid "notify_on_cancel_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been canceled."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:473
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:484
 msgid "notify_on_cancel_help"
 msgstr ""
 
@@ -1529,7 +1497,7 @@ msgid "notify_on_cancel_subject_help"
 msgstr ""
 
 #. Default: "Notify when confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:445
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:456
 msgid "notify_on_confirm"
 msgstr ""
 
@@ -1544,7 +1512,7 @@ msgid "notify_on_confirm_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been confirmed."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:446
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:457
 msgid "notify_on_confirm_help"
 msgstr ""
 
@@ -1590,7 +1558,7 @@ msgid "notify_on_confirm_subject_help"
 msgstr ""
 
 #. Default: "Notify when moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:454
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:465
 msgid "notify_on_move"
 msgstr ""
 
@@ -1605,7 +1573,7 @@ msgid "notify_on_move_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been moved."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:455
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:466
 msgid "notify_on_move_help"
 msgstr ""
 
@@ -1651,7 +1619,7 @@ msgid "notify_on_move_subject_help"
 msgstr ""
 
 #. Default: "Notify when rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:463
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:474
 msgid "notify_on_refuse"
 msgstr ""
 
@@ -1666,7 +1634,7 @@ msgid "notify_on_refuse_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been rejected."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:464
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:475
 msgid "notify_on_refuse_help"
 msgstr ""
 
@@ -1712,7 +1680,7 @@ msgid "notify_on_refuse_subject_help"
 msgstr ""
 
 #. Default: "Notify when created."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:436
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:447
 msgid "notify_on_submit"
 msgstr ""
 
@@ -1727,7 +1695,7 @@ msgid "notify_on_submit_appio_subject_default_value"
 msgstr ""
 
 #. Default: "Notify via mail the user when his booking has been created. If auto-confirm flag is selected and confirm notify is selected, this one will be ignored."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:437
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:448
 msgid "notify_on_submit_help"
 msgstr ""
 
@@ -1854,12 +1822,12 @@ msgid "reject_booking"
 msgstr ""
 
 #. Default: "Set how many days before of a booking date the user will be notified about it."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:497
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:508
 msgid "reminder_notification_gap_description"
 msgstr ""
 
 #. Default: "Booking reminder days"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:493
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:504
 msgid "reminder_notification_gap_label"
 msgstr ""
 
@@ -1942,7 +1910,7 @@ msgid "to_month_too_days_error"
 msgstr ""
 
 #. Default: "You can't add a booking with type '${booking_type}'."
-#: redturtle/prenotazioni/restapi/services/booking/add.py:132
+#: redturtle/prenotazioni/restapi/services/booking/add.py:135
 msgid "unauthorized_add_vacation"
 msgstr ""
 
@@ -1968,12 +1936,12 @@ msgid "view_booking"
 msgstr ""
 
 #. Default: "Insert here week schema for some custom date intervals."
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:307
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:318
 msgid "week_table_overrides_help"
 msgstr ""
 
 #. Default: "Week table overrides"
-#: redturtle/prenotazioni/content/prenotazioni_folder.py:306
+#: redturtle/prenotazioni/content/prenotazioni_folder.py:317
 msgid "week_table_overrides_label"
 msgstr ""
 

--- a/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
+++ b/src/redturtle/prenotazioni/locales/redturtle.prenotazioni.pot
@@ -46,7 +46,7 @@ msgstr ""
 
 #: redturtle/prenotazioni/content/prenotazioni_folder.py:216
 msgid "Apply restrictions to Bookings Manager"
-msgstr ""
+msgstr "Applica le restrizioni sulle date anche agli operatori"
 
 #: redturtle/prenotazioni/browser/templates/prenotazione.pt:29
 msgid "Attention"

--- a/src/redturtle/prenotazioni/tests/test_pauses_overrides.py
+++ b/src/redturtle/prenotazioni/tests/test_pauses_overrides.py
@@ -4,6 +4,7 @@ import unittest
 from datetime import date
 
 import transaction
+from freezegun import freeze_time
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -14,6 +15,8 @@ from plone.restapi.testing import RelativeSession
 from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_API_FUNCTIONAL_TESTING
 from redturtle.prenotazioni.testing import REDTURTLE_PRENOTAZIONI_FUNCTIONAL_TESTING
 from redturtle.prenotazioni.tests.helpers import WEEK_TABLE_SCHEMA
+
+TESTING_DATE = "2023-01-05"
 
 
 class TestPausesOverride(unittest.TestCase):
@@ -193,7 +196,7 @@ class TestPauseOverrideAPIPost(unittest.TestCase):
             container=self.portal,
             type="PrenotazioniFolder",
             title="Prenota foo",
-            daData=date.today(),
+            daData=date(year=2023, month=1, day=5),
             gates=["Gate A"],
             pause_table=[
                 {"day": "0", "pause_start": "0900", "pause_end": "0915"},
@@ -277,6 +280,7 @@ class TestPauseOverrideAPIPost(unittest.TestCase):
     def tearDown(self):
         self.api_session.close()
 
+    @freeze_time(TESTING_DATE)
     def test_add_booking_in_overrided_pause_return_400(self):
         self.api_session.auth = None
         booking_date = "{}T11:00:00+00:00".format(
@@ -300,6 +304,7 @@ class TestPauseOverrideAPIPost(unittest.TestCase):
             res.json()["message"], "Sorry, this slot is not available anymore."
         )
 
+    @freeze_time(TESTING_DATE)
     def test_add_booking_outside_overrided_pause_return_200(self):
         self.api_session.auth = None
         booking_date = "{}T09:00:00+00:00".format(

--- a/src/redturtle/prenotazioni/tests/test_prenotazioni_search.py
+++ b/src/redturtle/prenotazioni/tests/test_prenotazioni_search.py
@@ -627,6 +627,7 @@ class TestPrenotazioniUserSearch(unittest.TestCase):
         res = self.anon_session.get(
             f"{self.folder_prenotazioni.absolute_url()}/@available-slots"
         )
+
         booking_date = res.json()["items"][0]
         # anonymous user 1
         res = self.add_booking(

--- a/src/redturtle/prenotazioni/utilities/dateutils.py
+++ b/src/redturtle/prenotazioni/utilities/dateutils.py
@@ -73,3 +73,22 @@ def hm2seconds(hm):
         return None
     h, m = hm2handm(hm)
     return int(h) * 3600 + int(m) * 60
+
+
+def exceedes_date_limit(data, future_days):
+    """
+    Check if the booking date exceedes the date limit
+    """
+    if not future_days:
+        return False
+    booking_date = data.get("booking_date", None)
+    if not isinstance(booking_date, datetime):
+        return False
+    date_limit = tznow() + timedelta(future_days)
+    if not booking_date.tzinfo:
+        tzinfo = date_limit.tzinfo
+        if tzinfo:
+            booking_date = tzinfo.localize(booking_date)
+    if booking_date <= date_limit:
+        return False
+    return True

--- a/src/redturtle/prenotazioni/utilities/dateutils.py
+++ b/src/redturtle/prenotazioni/utilities/dateutils.py
@@ -73,22 +73,3 @@ def hm2seconds(hm):
         return None
     h, m = hm2handm(hm)
     return int(h) * 3600 + int(m) * 60
-
-
-def exceedes_date_limit(data, future_days):
-    """
-    Check if the booking date exceedes the date limit
-    """
-    if not future_days:
-        return False
-    booking_date = data.get("booking_date", None)
-    if not isinstance(booking_date, datetime):
-        return False
-    date_limit = tznow() + timedelta(future_days)
-    if not booking_date.tzinfo:
-        tzinfo = date_limit.tzinfo
-        if tzinfo:
-            booking_date = tzinfo.localize(booking_date)
-    if booking_date <= date_limit:
-        return False
-    return True


### PR DESCRIPTION
- Add possibility to restrict also a Bookings Manager by the validity dates of a Booking Folder.
- Add validity dates checks during the booking creation. Actually is not considered so u can create booking for the every date you want