### PR TITLE
workaround for empty contact

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.7.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Workaround for empty contacts
+  [mamico]
 
 
 2.7.7 (2024-08-22)

--- a/src/redturtle/prenotazioni/restapi/serializers/adapters/prenotazioni_folder.py
+++ b/src/redturtle/prenotazioni/restapi/serializers/adapters/prenotazioni_folder.py
@@ -21,4 +21,9 @@ class PrenotazioniFolderSerializer(SerializeFolderToJson):
             for i in self.context.get_booking_types()
         ]
 
+        # Questo è un workaround per gesitire il caso in cui ci siano uffici correlati con contatti vuoti
+        if res.get("uffici_correlati"):
+            for ufficio in res["uffici_correlati"]:
+                ufficio["contact_info"] = [contact for contact in ufficio.get("contact_info") or [] if contact]
+
         return res

--- a/src/redturtle/prenotazioni/restapi/serializers/adapters/prenotazioni_folder.py
+++ b/src/redturtle/prenotazioni/restapi/serializers/adapters/prenotazioni_folder.py
@@ -24,6 +24,8 @@ class PrenotazioniFolderSerializer(SerializeFolderToJson):
         # Questo è un workaround per gesitire il caso in cui ci siano uffici correlati con contatti vuoti
         if res.get("uffici_correlati"):
             for ufficio in res["uffici_correlati"]:
-                ufficio["contact_info"] = [contact for contact in ufficio.get("contact_info") or [] if contact]
+                ufficio["contact_info"] = [
+                    contact for contact in ufficio.get("contact_info") or [] if contact
+                ]
 
         return res


### PR DESCRIPTION
This is a workaround for not returning `null` contact points. Strangely, they return when serializing an organizational unit as a relation and not if you serialize the organizational unit directly